### PR TITLE
Feature: refactor

### DIFF
--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -1,3 +1,5 @@
+import { localizedPath } from '../support/paths';
+
 const viewports = [
   { label: 'desktop', apply: () => cy.viewport(1280, 800) },
   { label: 'mobile', apply: () => cy.viewport('iphone-6') },
@@ -14,7 +16,7 @@ describe('Homepage JA', () => {
     context(label, () => {
       beforeEach(() => {
         apply();
-        cy.visit('/');
+        cy.visit(localizedPath('ja'));
       });
 
       it('shows main hero and contact info', () => {
@@ -51,7 +53,7 @@ describe('Homepage JA', () => {
           cy.get('#mobile-menu').should('exist');
           cy.contains('#mobile-menu nav a', 'Links').first().click();
           cy.get('#mobile-menu').should('not.exist');
-          cy.location('pathname').should('match', /\/links\/?$/);
+          cy.location('pathname').should('eq', localizedPath('ja', '/links/'));
         });
       } else {
         it('navigates to a blog post when clicking a card', () => {
@@ -60,13 +62,13 @@ describe('Homepage JA', () => {
             if (link) {
               cy.wrap(link).click({ force: true });
             } else {
-              cy.get('a[href="/blogs/"]').first().click({ force: true });
-              cy.location('pathname', { timeout: 10000 }).should('match', /\/blogs\/?$/);
-              cy.get('[data-testid="blog-card"] a[href^="/blogs/"]').first().click({ force: true });
+              cy.get(`a[href="${localizedPath('ja', '/blogs/')}"]`).first().click({ force: true });
+              cy.location('pathname', { timeout: 10000 }).should('eq', localizedPath('ja', '/blogs/'));
+              cy.get('[data-testid="blog-card"] a[href*="/blogs/"]').first().click({ force: true });
             }
           });
           cy.location('pathname', { timeout: 10000 }).should((pathname) => {
-            expect(pathname).to.match(/\/blogs\/[\w-]+\/?$/);
+            expect(pathname).to.match(/\/(?:ja\/)?blogs\/[\w-]+\/?$/);
           });
         });
       }
@@ -79,7 +81,7 @@ describe('Homepage EN', () => {
     context(label, () => {
       beforeEach(() => {
         apply();
-        cy.visit('/en');
+        cy.visit(localizedPath('en'));
       });
 
       it('shows localized content', () => {

--- a/cypress/e2e/site-pages.cy.ts
+++ b/cypress/e2e/site-pages.cy.ts
@@ -1,3 +1,5 @@
+import { localizedPath } from '../support/paths';
+
 const viewports = [
   { label: 'desktop', apply: () => cy.viewport(1280, 800) },
   { label: 'mobile', apply: () => cy.viewport('iphone-6') },
@@ -8,11 +10,11 @@ describe('Blog index page', () => {
     context(label, () => {
       beforeEach(() => {
         apply();
-        cy.visit('/blogs/');
+        cy.visit(localizedPath('ja', '/blogs/'));
       });
 
       it('lists blog posts with metadata', () => {
-        cy.contains('h1', '📝 ブログ').should('be.visible');
+        cy.contains('h1', '📝 Blog').should('be.visible');
         cy.contains('h2', '✨ 最新').parents('section').find('li').should('have.length.at.least', 1);
         cy.contains('h2', '🗂 すべての記事')
           .parents('section')
@@ -28,10 +30,12 @@ describe('Blog index page', () => {
         it('navigates to detail when clicking a blog card', () => {
           cy.contains('h2', '🗂 すべての記事')
             .parents('section')
-            .find('[data-testid="blog-card"] a[href^="/blogs/"]')
+            .find('[data-testid="blog-card"] a[href*="/blogs/"]')
             .first()
             .click({ force: true });
-          cy.location('pathname', { timeout: 10000 }).should('match', /\/blogs\/[\w-]+\/?$/);
+          cy.location('pathname', { timeout: 10000 }).should((pathname) => {
+            expect(pathname).to.match(/\/(?:ja\/)?blogs\/[\w-]+\/?$/);
+          });
         });
       }
     });
@@ -43,7 +47,7 @@ describe('Links page', () => {
     context(label, () => {
       beforeEach(() => {
         apply();
-        cy.visit('/links/');
+        cy.visit(localizedPath('en', '/links/'));
       });
 
       it('groups external links by category', () => {
@@ -81,7 +85,7 @@ describe('Publications page', () => {
     context(label, () => {
       beforeEach(() => {
         apply();
-        cy.visit('/publications/', {
+        cy.visit(localizedPath('en', '/publications/'), {
           onBeforeLoad(win) {
             cy.stub(win, 'open').as('publicationOpen');
           },
@@ -112,7 +116,7 @@ describe('Localized page variants', () => {
   it('renders the Japanese blog index', () => {
     cy.viewport(1280, 800);
     cy.visit('/ja/blogs/');
-    cy.contains('h1', '📝 ブログ').should('be.visible');
+    cy.contains('h1', '📝 Blog').should('be.visible');
   });
 
   it('renders the English blog index', () => {

--- a/cypress/support/paths.ts
+++ b/cypress/support/paths.ts
@@ -1,0 +1,8 @@
+export function localizedPath(locale: 'ja' | 'en', path: string = '/'): string {
+  const normalized = path.endsWith('/') ? path : `${path}/`;
+  if (normalized === '/' || normalized === '/ja/' || normalized === '/en/') {
+    return locale === 'ja' ? '/ja/' : '/en/';
+  }
+  const withSlash = normalized.startsWith('/') ? normalized : `/${normalized}`;
+  return `/${locale}${withSlash}`.replace(/\\+/g, '/');
+}

--- a/src/app/(site)/[locale]/blogs/page.tsx
+++ b/src/app/(site)/[locale]/blogs/page.tsx
@@ -1,10 +1,9 @@
 import type { Metadata } from 'next';
 import { getAllPosts } from '@/lib/content/blog';
 import { BlogsClient } from '@/app/blogs/sections/BlogsClient';
-import { buildPageMetadata, defaultLanguageAlternates } from '@/lib/seo';
+import { buildLocalizedMetadata, localizedStaticParams } from '@/lib/metadata';
 import type { Locale } from '@/lib/i18n';
 import {
-  SUPPORTED_LOCALES,
   blogsPageCopy,
   resolveLocale,
 } from '@/app/(site)/_config/pageCopy';
@@ -13,22 +12,12 @@ type Params = {
   locale: string;
 };
 
-export function generateStaticParams() {
-  return SUPPORTED_LOCALES.map((locale) => ({ locale }));
-}
+export const generateStaticParams = localizedStaticParams;
 
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
-  const locale = resolveLocale((await params).locale);
-  const copy = blogsPageCopy[locale];
-  return buildPageMetadata({
-    title: copy.metadataTitle,
-    description: copy.metadataDescription,
-    locale,
-    path: copy.path,
-    languageAlternates: defaultLanguageAlternates,
-  });
+  return buildLocalizedMetadata(params, blogsPageCopy);
 }
 
 export default async function LocaleBlogsPage({ params }: { params: Promise<Params> }) {

--- a/src/app/(site)/[locale]/blogs/page.tsx
+++ b/src/app/(site)/[locale]/blogs/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { getAllPosts } from '@/lib/content/blog';
 import { BlogsClient } from '@/app/blogs/sections/BlogsClient';
 import { buildLocalizedMetadata, localizedStaticParams } from '@/lib/metadata';
+import { pageMeta } from '@/lib/seo/metaConfig';
 import type { Locale } from '@/lib/i18n';
 import {
   blogsPageCopy,
@@ -17,7 +18,7 @@ export const generateStaticParams = localizedStaticParams;
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
-  return buildLocalizedMetadata(params, blogsPageCopy);
+  return buildLocalizedMetadata(params, pageMeta.blogs);
 }
 
 export default async function LocaleBlogsPage({ params }: { params: Promise<Params> }) {

--- a/src/app/(site)/[locale]/links/page.tsx
+++ b/src/app/(site)/[locale]/links/page.tsx
@@ -3,6 +3,7 @@ import { LinksPage } from '@/app/(site)/_components/LinksPage';
 import type { Locale } from '@/lib/i18n';
 import { buildLocalizedMetadata, localizedStaticParams } from '@/lib/metadata';
 import { linksPageCopy, resolveLocale } from '@/app/(site)/_config/pageCopy';
+import { pageMeta } from '@/lib/seo/metaConfig';
 
 type Params = { locale: string };
 
@@ -11,7 +12,7 @@ export const generateStaticParams = localizedStaticParams;
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
-  return buildLocalizedMetadata(params, linksPageCopy);
+  return buildLocalizedMetadata(params, pageMeta.links);
 }
 
 export default async function LocaleLinksPage({ params }: { params: Promise<Params> }) {

--- a/src/app/(site)/[locale]/links/page.tsx
+++ b/src/app/(site)/[locale]/links/page.tsx
@@ -1,31 +1,17 @@
 import type { Metadata } from 'next';
 import { LinksPage } from '@/app/(site)/_components/LinksPage';
 import type { Locale } from '@/lib/i18n';
-import { buildPageMetadata, defaultLanguageAlternates } from '@/lib/seo';
-import {
-  SUPPORTED_LOCALES,
-  linksPageCopy,
-  resolveLocale,
-} from '@/app/(site)/_config/pageCopy';
+import { buildLocalizedMetadata, localizedStaticParams } from '@/lib/metadata';
+import { linksPageCopy, resolveLocale } from '@/app/(site)/_config/pageCopy';
 
 type Params = { locale: string };
 
-export function generateStaticParams() {
-  return SUPPORTED_LOCALES.map((locale) => ({ locale }));
-}
+export const generateStaticParams = localizedStaticParams;
 
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
-  const locale = resolveLocale((await params).locale);
-  const copy = linksPageCopy[locale];
-  return buildPageMetadata({
-    title: copy.metadataTitle,
-    description: copy.metadataDescription,
-    locale,
-    path: copy.path,
-    languageAlternates: defaultLanguageAlternates,
-  });
+  return buildLocalizedMetadata(params, linksPageCopy);
 }
 
 export default async function LocaleLinksPage({ params }: { params: Promise<Params> }) {

--- a/src/app/(site)/[locale]/page.tsx
+++ b/src/app/(site)/[locale]/page.tsx
@@ -1,32 +1,25 @@
 import type { Metadata } from 'next';
 import HomeContent from '@/components/home/HomeContent';
 import type { Locale } from '@/lib/i18n';
-import { buildPageMetadata, defaultLanguageAlternates, siteConfig } from '@/lib/seo';
-import { SUPPORTED_LOCALES, resolveLocale } from '@/app/(site)/_config/pageCopy';
+import { buildLocalizedMetadata, localizedStaticParams } from '@/lib/metadata';
+import { resolveLocale } from '@/lib/i18n';
+import { siteConfig } from '@/lib/seo';
 
 type Params = {
   locale: string;
 };
 
-function resolvePath(locale: Locale): string {
-  return locale === 'ja' ? '/ja/' : '/en/';
-}
+const homeCopy: Record<Locale, { metadataTitle: string; metadataDescription: string; path: string }> = {
+  ja: { metadataTitle: siteConfig.defaultTitle.ja, metadataDescription: siteConfig.description.ja, path: '/ja/' },
+  en: { metadataTitle: siteConfig.defaultTitle.en, metadataDescription: siteConfig.description.en, path: '/en/' },
+};
 
-export function generateStaticParams() {
-  return SUPPORTED_LOCALES.map((locale) => ({ locale }));
-}
+export const generateStaticParams = localizedStaticParams;
 
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
-  const locale = resolveLocale((await params).locale);
-  return buildPageMetadata({
-    title: siteConfig.defaultTitle[locale],
-    description: siteConfig.description[locale],
-    locale,
-    path: resolvePath(locale),
-    languageAlternates: defaultLanguageAlternates,
-  });
+  return buildLocalizedMetadata(params, homeCopy);
 }
 
 export default async function LocaleHomePage({ params }: { params: Promise<Params> }) {

--- a/src/app/(site)/[locale]/page.tsx
+++ b/src/app/(site)/[locale]/page.tsx
@@ -3,15 +3,10 @@ import HomeContent from '@/components/home/HomeContent';
 import type { Locale } from '@/lib/i18n';
 import { buildLocalizedMetadata, localizedStaticParams } from '@/lib/metadata';
 import { resolveLocale } from '@/lib/i18n';
-import { siteConfig } from '@/lib/seo';
+import { pageMeta } from '@/lib/seo/metaConfig';
 
 type Params = {
   locale: string;
-};
-
-const homeCopy: Record<Locale, { metadataTitle: string; metadataDescription: string; path: string }> = {
-  ja: { metadataTitle: siteConfig.defaultTitle.ja, metadataDescription: siteConfig.description.ja, path: '/ja/' },
-  en: { metadataTitle: siteConfig.defaultTitle.en, metadataDescription: siteConfig.description.en, path: '/en/' },
 };
 
 export const generateStaticParams = localizedStaticParams;
@@ -19,7 +14,7 @@ export const generateStaticParams = localizedStaticParams;
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
-  return buildLocalizedMetadata(params, homeCopy);
+  return buildLocalizedMetadata(params, pageMeta.home);
 }
 
 export default async function LocaleHomePage({ params }: { params: Promise<Params> }) {

--- a/src/app/(site)/[locale]/publications/page.tsx
+++ b/src/app/(site)/[locale]/publications/page.tsx
@@ -1,31 +1,17 @@
 import type { Metadata } from 'next';
 import { PublicationsPage } from '@/app/(site)/_components/PublicationsPage';
 import type { Locale } from '@/lib/i18n';
-import { buildPageMetadata, defaultLanguageAlternates } from '@/lib/seo';
-import {
-  SUPPORTED_LOCALES,
-  publicationsPageCopy,
-  resolveLocale,
-} from '@/app/(site)/_config/pageCopy';
+import { buildLocalizedMetadata, localizedStaticParams } from '@/lib/metadata';
+import { publicationsPageCopy, resolveLocale } from '@/app/(site)/_config/pageCopy';
 
 type Params = { locale: string };
 
-export function generateStaticParams() {
-  return SUPPORTED_LOCALES.map((locale) => ({ locale }));
-}
+export const generateStaticParams = localizedStaticParams;
 
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
-  const locale = resolveLocale((await params).locale);
-  const copy = publicationsPageCopy[locale];
-  return buildPageMetadata({
-    title: copy.metadataTitle,
-    description: copy.metadataDescription,
-    locale,
-    path: copy.path,
-    languageAlternates: defaultLanguageAlternates,
-  });
+  return buildLocalizedMetadata(params, publicationsPageCopy);
 }
 
 export default async function LocalePublicationsPage({ params }: { params: Promise<Params> }) {

--- a/src/app/(site)/[locale]/publications/page.tsx
+++ b/src/app/(site)/[locale]/publications/page.tsx
@@ -3,6 +3,7 @@ import { PublicationsPage } from '@/app/(site)/_components/PublicationsPage';
 import type { Locale } from '@/lib/i18n';
 import { buildLocalizedMetadata, localizedStaticParams } from '@/lib/metadata';
 import { publicationsPageCopy, resolveLocale } from '@/app/(site)/_config/pageCopy';
+import { pageMeta } from '@/lib/seo/metaConfig';
 
 type Params = { locale: string };
 
@@ -11,7 +12,7 @@ export const generateStaticParams = localizedStaticParams;
 export const dynamicParams = false;
 
 export async function generateMetadata({ params }: { params: Promise<Params> }): Promise<Metadata> {
-  return buildLocalizedMetadata(params, publicationsPageCopy);
+  return buildLocalizedMetadata(params, pageMeta.publications);
 }
 
 export default async function LocalePublicationsPage({ params }: { params: Promise<Params> }) {

--- a/src/app/(site)/_components/LinksPage.tsx
+++ b/src/app/(site)/_components/LinksPage.tsx
@@ -1,8 +1,7 @@
-import clsx from 'clsx';
-import { ExternalIcon } from '@/components/ui/ExternalIcon';
 import { getLinks } from '@/lib/data/links';
 import type { Locale } from '@/lib/i18n';
 import { linksPageCopy } from '@/app/(site)/_config/pageCopy';
+import { LinkGrid } from '@/components/links/LinkGrid';
 
 type LinkItem = Awaited<ReturnType<typeof getLinks>>[number];
 
@@ -12,29 +11,6 @@ export async function LinksPage({ locale }: { locale: Locale }) {
   const groups = groupBy(links, (l) => l.category || copy.groupFallback);
   const mobileLimit = 3;
 
-  const renderLinkItem = (key: string, l: LinkItem, extraClassName?: string) => (
-    <li key={key} className={clsx('card p-4 text-center', extraClassName)}>
-      <a href={l.url} target="_blank" rel="noreferrer" className="inline-block mb-2">
-        {l.iconUrl ? (
-          <ExternalIcon src={l.iconUrl} alt={l.title} size={48} />
-        ) : (
-          <span className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-gray-100 dark:bg-gray-800 text-lg">
-            {l.title.slice(0, 1)}
-          </span>
-        )}
-      </a>
-      <a
-        href={l.url}
-        target="_blank"
-        rel="noreferrer"
-        className="font-medium underline-offset-2 hover:underline block"
-      >
-        {l.title}
-      </a>
-      {l.desc ? <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{l.desc}</p> : null}
-    </li>
-  );
-
   return (
     <div className="space-y-6">
       <div className="text-sm opacity-70">{copy.breadcrumb}</div>
@@ -42,23 +18,14 @@ export async function LinksPage({ locale }: { locale: Locale }) {
       {Object.entries(groups).map(([cat, items]) => (
         <section key={cat} className="space-y-2">
           <h2 className="text-xl font-semibold">{cat}</h2>
-          <ul className="grid grid-cols-2 sm:grid-cols-3 gap-4">
-            {items.map((l, index) =>
-              renderLinkItem(
-                `${cat}-primary-${l.url}`,
-                l,
-                index >= mobileLimit ? 'hidden sm:block' : undefined,
-              ),
-            )}
-          </ul>
-          {items.length > mobileLimit ? (
-            <details className="sm:hidden">
-              <summary className="cursor-pointer text-sm underline">{copy.moreLabel}</summary>
-              <ul className="grid grid-cols-2 gap-4 mt-3">
-                {items.slice(mobileLimit).map((l) => renderLinkItem(`${cat}-mobile-${l.url}`, l))}
-              </ul>
-            </details>
-          ) : null}
+          <LinkGrid
+            items={items}
+            mobileLimit={mobileLimit}
+            showDescription
+            moreLabel={copy.moreLabel}
+            iconSize={48}
+            gridClassName="grid grid-cols-2 sm:grid-cols-3 gap-4"
+          />
         </section>
       ))}
     </div>

--- a/src/app/(site)/_config/pageCopy.ts
+++ b/src/app/(site)/_config/pageCopy.ts
@@ -1,5 +1,6 @@
 import type { Locale } from '@/lib/i18n';
 import { SUPPORTED_LOCALES, resolveLocale } from '@/lib/i18n';
+import { pageMeta } from '@/lib/seo/metaConfig';
 
 export { SUPPORTED_LOCALES, resolveLocale };
 
@@ -15,17 +16,12 @@ export type BlogsPageCopy = PageCopy;
 
 export const blogsPageCopy: Record<Locale, BlogsPageCopy> = {
   ja: {
-    metadataTitle: 'ブログ記事一覧',
-    metadataDescription: '岡田 龍樹による自然言語処理や機械学習に関するブログ記事の一覧です。',
-    path: '/ja/blogs/',
-    heading: '📝 ブログ',
-    breadcrumb: '🏠 Home / 📝 ブログ',
+    ...pageMeta.blogs.ja,
+    heading: '📝 Blog',
+    breadcrumb: '🏠 Home / 📝 Blog',
   },
   en: {
-    metadataTitle: 'Blog Posts',
-    metadataDescription:
-      'Browse blog posts by Tatsuki Okada about natural language processing, machine learning, and development.',
-    path: '/en/blogs/',
+    ...pageMeta.blogs.en,
     heading: '📝 Blog',
     breadcrumb: '🏠 Home / 📝 Blog',
   },
@@ -38,19 +34,14 @@ export type LinksPageCopy = PageCopy<{
 
 export const linksPageCopy: Record<Locale, LinksPageCopy> = {
   ja: {
-    metadataTitle: 'リンク集',
-    metadataDescription: 'SNSアカウントやプロジェクトなど、岡田 龍樹に関連する外部リンクをまとめています。',
-    path: '/ja/links/',
+    ...pageMeta.links.ja,
     heading: '🔗 リンク',
     breadcrumb: '🏠 Home / 🔗 リンク',
     groupFallback: 'その他',
     moreLabel: 'さらに表示',
   },
   en: {
-    metadataTitle: 'Links',
-    metadataDescription:
-      "A curated list of Tatsuki Okada social accounts, projects, and recommended resources.",
-    path: '/en/links/',
+    ...pageMeta.links.en,
     heading: '🔗 Links',
     breadcrumb: '🏠 Home / 🔗 Links',
     groupFallback: 'Other',
@@ -62,17 +53,12 @@ export type PublicationsPageCopy = PageCopy;
 
 export const publicationsPageCopy: Record<Locale, PublicationsPageCopy> = {
   ja: {
-    metadataTitle: '公開物',
-    metadataDescription: '研究論文や記事、登壇資料など、岡田龍樹が携わった公開物の一覧です。',
-    path: '/ja/publications/',
+    ...pageMeta.publications.ja,
     heading: '📚 公開物',
     breadcrumb: '🏠 Home / 📚 公開物',
   },
   en: {
-    metadataTitle: 'Publications',
-    metadataDescription:
-      'Academic publications, articles, and talks by Tatsuki Okada in the field of NLP and machine learning.',
-    path: '/en/publications/',
+    ...pageMeta.publications.en,
     heading: '📚 Publications',
     breadcrumb: '🏠 Home / 📚 Publications',
   },

--- a/src/app/(site)/_config/pageCopy.ts
+++ b/src/app/(site)/_config/pageCopy.ts
@@ -1,6 +1,7 @@
 import type { Locale } from '@/lib/i18n';
+import { SUPPORTED_LOCALES, resolveLocale } from '@/lib/i18n';
 
-export const SUPPORTED_LOCALES: Locale[] = ['ja', 'en'];
+export { SUPPORTED_LOCALES, resolveLocale };
 
 export type PageCopy<T extends Record<string, unknown> = {}> = {
   metadataTitle: string;
@@ -76,7 +77,3 @@ export const publicationsPageCopy: Record<Locale, PublicationsPageCopy> = {
     breadcrumb: '🏠 Home / 📚 Publications',
   },
 };
-
-export function resolveLocale(raw: string): Locale {
-  return raw === 'en' ? 'en' : 'ja';
-}

--- a/src/app/blogs/page.tsx
+++ b/src/app/blogs/page.tsx
@@ -4,15 +4,17 @@ import { getAllPosts } from '@/lib/content/blog';
 import { BlogsClient } from './sections/BlogsClient';
 import { buildPageMetadata, defaultLanguageAlternates } from '@/lib/seo';
 import { blogsPageCopy } from '@/app/(site)/_config/pageCopy';
+import { getPageMeta } from '@/lib/seo/metaConfig';
 
 const DEFAULT_LOCALE: Locale = 'ja';
 const copy = blogsPageCopy[DEFAULT_LOCALE];
+const pageMeta = getPageMeta('blogs', DEFAULT_LOCALE);
 
 export const metadata: Metadata = buildPageMetadata({
-  title: copy.metadataTitle,
-  description: copy.metadataDescription,
+  title: pageMeta.metadataTitle,
+  description: pageMeta.metadataDescription,
   locale: DEFAULT_LOCALE,
-  path: '/blogs/',
+  path: pageMeta.path,
   languageAlternates: defaultLanguageAlternates,
 });
 

--- a/src/app/blogs/sections/BlogsClient.tsx
+++ b/src/app/blogs/sections/BlogsClient.tsx
@@ -7,6 +7,7 @@ import { useSearchFilters } from '@/hooks/useSearchFilters';
 import { YearSelect } from '@/components/filters/YearSelect';
 import { TagSelector } from '@/components/filters/TagSelector';
 import { FilterBar } from '@/components/filters/FilterBar';
+import { resolveFilterText } from '@/components/filters/filterTexts';
 
 type Post = {
   slug: string;
@@ -60,45 +61,25 @@ export function BlogsClient({ posts, locale = 'en' }: { posts: Post[]; locale?: 
   const latest = filtered.slice(0, 3);
   const items = filtered.slice(0, visible);
 
-  const t = (key: string) => {
-    const ja: Record<string, string> = {
-      search: '検索...',
-      latest: '✨ 最新',
-      allPosts: '🗂 すべての記事',
-      noResult: '該当する記事がありません',
-      year: '年',
-      tags: 'タグ',
-      clear: 'クリア',
-    };
-    const en: Record<string, string> = {
-      search: 'Search...',
-      latest: '✨ Latest',
-      allPosts: '🗂 All Posts',
-      noResult: 'No posts found',
-      year: 'Year',
-      tags: 'Tags',
-      clear: 'Clear',
-    };
-    return (locale === 'ja' ? ja : en)[key];
-  };
+  const t = resolveFilterText(locale);
 
   return (
     <div className="space-y-6">
       <FilterBar
         query={q}
         onQueryChange={setQ}
-        placeholder={t('search')}
+        placeholder={t.search}
         onClear={() => {
           clearFilters();
         }}
-        clearLabel={t('clear')}
+        clearLabel={t.clear}
         hasActiveFilters={Boolean(year || tagSet.size)}
       >
         <YearSelect
           years={allYears}
           value={year}
           onChange={setYear}
-          label={t('year')}
+          label={t.year}
         />
 
         <TagSelector
@@ -110,13 +91,13 @@ export function BlogsClient({ posts, locale = 'en' }: { posts: Post[]; locale?: 
             else next.add(tag);
             setTagSet(next);
           }}
-          label={t('tags')}
+          label={t.tags}
           className="ml-2"
         />
       </FilterBar>
 
       <section>
-        <h2 className="text-xl font-semibold mb-2">{t('latest')}</h2>
+        <h2 className="text-xl font-semibold mb-2">{t.latest}</h2>
         <ul className="grid gap-3 sm:grid-cols-2" data-testid="blog-latest-list">
           {latest.map((p) => (
             <li key={p.slug} className="card overflow-hidden" data-testid="blog-latest-card">
@@ -146,9 +127,9 @@ export function BlogsClient({ posts, locale = 'en' }: { posts: Post[]; locale?: 
       </section>
 
       <section>
-        <h2 className="text-xl font-semibold mb-2">{t('allPosts')}</h2>
+        <h2 className="text-xl font-semibold mb-2">{t.allPosts}</h2>
         {items.length === 0 ? (
-          <p className="opacity-70">{t('noResult')}</p>
+          <p className="opacity-70">{t.noResult}</p>
         ) : (
           <ul className="space-y-2" data-testid="blog-all-list">
             {items.map((p) => (

--- a/src/app/blogs/sections/BlogsClient.tsx
+++ b/src/app/blogs/sections/BlogsClient.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link';
 import { formatDate } from '@/lib/date';
 import { withBasePath } from '@/lib/url';
 import { useSearchFilters } from '@/hooks/useSearchFilters';
+import { YearSelect } from '@/components/filters/YearSelect';
+import { TagSelector } from '@/components/filters/TagSelector';
 
 type Post = {
   slug: string;
@@ -90,35 +92,25 @@ export function BlogsClient({ posts, locale = 'en' }: { posts: Post[]; locale?: 
       />
 
       <div className="flex flex-wrap items-center gap-2">
-        <label className="text-sm opacity-70">{t('year')}</label>
-        <select value={year} onChange={(e)=>setYear(e.target.value)} className="border rounded-sm px-2 py-1 dark:border-gray-700">
-          <option value="">All</option>
-          {allYears.map(y => <option key={y} value={y}>{y}</option>)}
-        </select>
-        <details className="ml-2">
-          <summary className="cursor-pointer select-none text-sm opacity-80">
-            {t('tags')} ({allTags.length})
-          </summary>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {allTags.map((tag) => {
-              const active = tagSet.has(tag);
-              return (
-                <button
-                  key={tag}
-                  onClick={() => {
-                    const next = new Set(tagSet);
-                    if (active) next.delete(tag);
-                    else next.add(tag);
-                    setTagSet(next);
-                  }}
-                  className={`px-2 py-0.5 rounded-sm text-sm border ${active ? 'bg-gray-200 dark:bg-gray-700' : ''}`}
-                >
-                  #{tag}
-                </button>
-              );
-            })}
-          </div>
-        </details>
+        <YearSelect
+          years={allYears}
+          value={year}
+          onChange={setYear}
+          label={t('year')}
+        />
+
+        <TagSelector
+          tags={allTags}
+          selected={tagSet}
+          onToggle={(tag) => {
+            const next = new Set(tagSet);
+            if (next.has(tag)) next.delete(tag);
+            else next.add(tag);
+            setTagSet(next);
+          }}
+          label={t('tags')}
+          className="ml-2"
+        />
         {(year || tagSet.size || q) ? (
           <button onClick={()=>{ clearFilters(); }} className="ml-auto text-sm underline">
             {t('clear')}

--- a/src/app/blogs/sections/BlogsClient.tsx
+++ b/src/app/blogs/sections/BlogsClient.tsx
@@ -6,6 +6,7 @@ import { withBasePath } from '@/lib/url';
 import { useSearchFilters } from '@/hooks/useSearchFilters';
 import { YearSelect } from '@/components/filters/YearSelect';
 import { TagSelector } from '@/components/filters/TagSelector';
+import { FilterBar } from '@/components/filters/FilterBar';
 
 type Post = {
   slug: string;
@@ -83,15 +84,16 @@ export function BlogsClient({ posts, locale = 'en' }: { posts: Post[]; locale?: 
 
   return (
     <div className="space-y-6">
-      <input
-        aria-label={t('search')}
-        value={q}
-        onChange={(e) => setQ(e.target.value)}
+      <FilterBar
+        query={q}
+        onQueryChange={setQ}
         placeholder={t('search')}
-        className="w-full border rounded-sm px-3 py-2 dark:border-gray-700"
-      />
-
-      <div className="flex flex-wrap items-center gap-2">
+        onClear={() => {
+          clearFilters();
+        }}
+        clearLabel={t('clear')}
+        hasActiveFilters={Boolean(year || tagSet.size)}
+      >
         <YearSelect
           years={allYears}
           value={year}
@@ -111,12 +113,7 @@ export function BlogsClient({ posts, locale = 'en' }: { posts: Post[]; locale?: 
           label={t('tags')}
           className="ml-2"
         />
-        {(year || tagSet.size || q) ? (
-          <button onClick={()=>{ clearFilters(); }} className="ml-auto text-sm underline">
-            {t('clear')}
-          </button>
-        ) : null}
-      </div>
+      </FilterBar>
 
       <section>
         <h2 className="text-xl font-semibold mb-2">{t('latest')}</h2>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,6 +2,8 @@
 
 @plugin '@tailwindcss/typography';
 
+@import '../styles/ui.css';
+
 @custom-variant dark (&:is(.dark *));
 
 @theme {
@@ -73,8 +75,6 @@ a { @apply text-blue-600 dark:text-blue-400 underline-offset-2 hover:underline; 
   border-color: rgba(255,255,255,0.1);
 }
 .code-copy-btn.copied { background: #10b981; color: white; border-color: transparent; }
-.card { @apply border border-gray-200 dark:border-gray-800 rounded-lg bg-white dark:bg-gray-900 shadow-xs transition hover:shadow-md hover:-translate-y-0.5; }
-.tag { @apply inline-block px-2 py-0.5 rounded-sm bg-gray-100 dark:bg-gray-800 text-xs; }
 .focus-ring { @apply focus:outline-hidden focus-visible:ring-2 focus-visible:ring-brand; }
 .prose h2 { @apply mt-10 border-b border-gray-200 dark:border-gray-800 pb-1; }
 .prose h3 { @apply mt-8; }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import './globals.css';
 import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { ThemeProvider } from 'next-themes';
-import { withBasePath, withVersion } from '@/lib/url';
+import { assetPath, withBasePath, withVersion } from '@/lib/url';
 import { absoluteUrl, buildPageMetadata, defaultLanguageAlternates, siteConfig } from '@/lib/seo';
 import { Header } from '@/components/site/Header';
 import { Footer } from '@/components/site/Footer';
@@ -29,11 +29,11 @@ export const metadata: Metadata = {
   icons: {
     icon: [
       { url: withVersion(withBasePath('/favicon.ico'))!, type: 'image/x-icon' },
-      { url: withVersion(withBasePath('/favicon-32x32.png'))!, type: 'image/png', sizes: '32x32' },
-      { url: withVersion(withBasePath('/favicon-16x16.png'))!, type: 'image/png', sizes: '16x16' },
+      { url: assetPath('/favicon-32x32.png')!, type: 'image/png', sizes: '32x32' },
+      { url: assetPath('/favicon-16x16.png')!, type: 'image/png', sizes: '16x16' },
     ],
-    shortcut: withVersion(withBasePath('/favicon-32x32.png')),
-    apple: withVersion(withBasePath('/apple-touch-icon.png')),
+    shortcut: assetPath('/favicon-32x32.png'),
+    apple: assetPath('/apple-touch-icon.png'),
   },
   category: 'technology',
   applicationName: siteConfig.siteName.ja,
@@ -57,7 +57,7 @@ export default function RootLayout({
         <link
           rel="preload"
           as="image"
-          href={withVersion(withBasePath('/favicon.ico'))}
+          href={assetPath('/favicon.ico')}
           fetchPriority="high"
         />
       </head>

--- a/src/app/links/page.tsx
+++ b/src/app/links/page.tsx
@@ -3,15 +3,17 @@ import type { Locale } from '@/lib/i18n';
 import { LinksPage as LinksPageView } from '@/app/(site)/_components/LinksPage';
 import { buildPageMetadata, defaultLanguageAlternates } from '@/lib/seo';
 import { linksPageCopy } from '@/app/(site)/_config/pageCopy';
+import { getPageMeta } from '@/lib/seo/metaConfig';
 
 const DEFAULT_LOCALE: Locale = 'en';
 const copy = linksPageCopy[DEFAULT_LOCALE];
+const pageMeta = getPageMeta('links', DEFAULT_LOCALE);
 
 export const metadata: Metadata = buildPageMetadata({
-  title: copy.metadataTitle,
-  description: copy.metadataDescription,
+  title: pageMeta.metadataTitle,
+  description: pageMeta.metadataDescription,
   locale: DEFAULT_LOCALE,
-  path: '/links/',
+  path: pageMeta.path,
   languageAlternates: defaultLanguageAlternates,
 });
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,15 @@
 import type { Metadata } from 'next';
 import HomeContent from '@/components/home/HomeContent';
-import { buildPageMetadata, defaultLanguageAlternates, siteConfig } from '@/lib/seo';
+import { buildPageMetadata, defaultLanguageAlternates } from '@/lib/seo';
+import { getPageMeta } from '@/lib/seo/metaConfig';
+
+const homeMeta = getPageMeta('home', 'ja');
 
 export const metadata: Metadata = buildPageMetadata({
-  title: siteConfig.defaultTitle.ja,
-  description: siteConfig.description.ja,
+  title: homeMeta.metadataTitle,
+  description: homeMeta.metadataDescription,
   locale: 'ja',
-  path: '/',
+  path: homeMeta.path,
   languageAlternates: defaultLanguageAlternates,
 });
 

--- a/src/app/publications/page.tsx
+++ b/src/app/publications/page.tsx
@@ -3,15 +3,17 @@ import type { Locale } from '@/lib/i18n';
 import { PublicationsPage as PublicationsPageView } from '@/app/(site)/_components/PublicationsPage';
 import { buildPageMetadata, defaultLanguageAlternates } from '@/lib/seo';
 import { publicationsPageCopy } from '@/app/(site)/_config/pageCopy';
+import { getPageMeta } from '@/lib/seo/metaConfig';
 
 const DEFAULT_LOCALE: Locale = 'en';
 const copy = publicationsPageCopy[DEFAULT_LOCALE];
+const pageMeta = getPageMeta('publications', DEFAULT_LOCALE);
 
 export const metadata: Metadata = buildPageMetadata({
-  title: copy.metadataTitle,
-  description: copy.metadataDescription,
+  title: pageMeta.metadataTitle,
+  description: pageMeta.metadataDescription,
   locale: DEFAULT_LOCALE,
-  path: '/publications/',
+  path: pageMeta.path,
   languageAlternates: defaultLanguageAlternates,
 });
 

--- a/src/app/publications/sections/PublicationsClient.tsx
+++ b/src/app/publications/sections/PublicationsClient.tsx
@@ -4,6 +4,7 @@ import { withBasePath } from '@/lib/url';
 import { useSearchFilters } from '@/hooks/useSearchFilters';
 import { YearSelect } from '@/components/filters/YearSelect';
 import { TagSelector } from '@/components/filters/TagSelector';
+import { FilterBar } from '@/components/filters/FilterBar';
 
 type Item = {
   slug: string;
@@ -106,15 +107,17 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
 
   return (
     <div className="space-y-6">
-      <input
-        aria-label={t('search')}
-        value={q}
-        onChange={(e) => setQ(e.target.value)}
+      <FilterBar
+        query={q}
+        onQueryChange={setQ}
         placeholder={t('search')}
-        className="w-full border rounded-sm px-3 py-2 dark:border-gray-700"
-      />
-
-      <div className="flex flex-wrap items-center gap-2">
+        onClear={() => {
+          clearFilters();
+          setTypes({ paper: true, article: true, talk: true, slide: true, media: true, app: true });
+        }}
+        clearLabel={t('clear')}
+        hasActiveFilters={Boolean(year || tagSet.size || Object.values(types).some((v) => !v))}
+      >
         <YearSelect
           years={years}
           value={year}
@@ -146,19 +149,7 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
           label={t('tags')}
           className="ml-2"
         />
-
-        {(q || year || tagSet.size || Object.values(types).some(v=>!v)) ? (
-          <button
-            onClick={() => {
-              clearFilters();
-              setTypes({ paper: true, article: true, talk: true, slide: true, media: true, app: true });
-            }}
-            className="ml-auto text-sm underline"
-          >
-            {t('clear')}
-          </button>
-        ) : null}
-      </div>
+      </FilterBar>
 
       {order.map((type) => {
         const arr = groups[type] || [];

--- a/src/app/publications/sections/PublicationsClient.tsx
+++ b/src/app/publications/sections/PublicationsClient.tsx
@@ -5,6 +5,7 @@ import { useSearchFilters } from '@/hooks/useSearchFilters';
 import { YearSelect } from '@/components/filters/YearSelect';
 import { TagSelector } from '@/components/filters/TagSelector';
 import { FilterBar } from '@/components/filters/FilterBar';
+import { resolveFilterText } from '@/components/filters/filterTexts';
 
 type Item = {
   slug: string;
@@ -60,37 +61,24 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
     return map;
   }, [typeFiltered]);
 
-  const t = (key: string) => {
-    const ja: Record<string, string> = {
-      search: '検索...',
-      paper: '📄 論文',
-      article: '📝 技術ブログ',
-      talk: '🎤 登壇',
-      slide: '📑 スライド',
-      media: '📰 メディア',
-      app: '📱 アプリ',
-      year: '年',
-      types: '種類',
-      tags: 'タグ',
-      clear: 'クリア',
-      noResult: '該当する項目がありません',
-    };
-    const en: Record<string, string> = {
-      search: 'Search...',
-      paper: '📄 Papers',
-      article: '📝 Technical Articles',
-      talk: '🎤 Talks',
-      slide: '📑 Slides',
-      media: '📰 Media',
-      app: '📱 Apps',
-      year: 'Year',
-      types: 'Types',
-      tags: 'Tags',
-      clear: 'Clear',
-      noResult: 'No items found',
-    };
-    return (locale === 'ja' ? ja : en)[key];
-  };
+  const t = resolveFilterText(locale);
+  const typeLabels: Record<Item['type'], string> = locale === 'ja'
+    ? {
+        paper: '📄 論文',
+        article: '📝 技術ブログ',
+        talk: '🎤 登壇',
+        slide: '📑 スライド',
+        media: '📰 メディア',
+        app: '📱 アプリ',
+      }
+    : {
+        paper: '📄 Papers',
+        article: '📝 Technical Articles',
+        talk: '🎤 Talks',
+        slide: '📑 Slides',
+        media: '📰 Media',
+        app: '📱 Apps',
+      };
 
   const openInNewTab = (url?: string) => {
     if (!url || typeof window === 'undefined') return;
@@ -110,22 +98,22 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
       <FilterBar
         query={q}
         onQueryChange={setQ}
-        placeholder={t('search')}
+        placeholder={t.search}
         onClear={() => {
           clearFilters();
           setTypes({ paper: true, article: true, talk: true, slide: true, media: true, app: true });
         }}
-        clearLabel={t('clear')}
+        clearLabel={t.clear}
         hasActiveFilters={Boolean(year || tagSet.size || Object.values(types).some((v) => !v))}
       >
         <YearSelect
           years={years}
           value={year}
           onChange={setYear}
-          label={t('year')}
+          label={t.year}
         />
 
-        <span className="text-sm opacity-70">{t('types')}</span>
+        <span className="text-sm opacity-70">{t.types}</span>
         {order.map((tp) => (
           <label key={tp} className="text-sm inline-flex items-center gap-1">
             <input
@@ -133,7 +121,7 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
               checked={types[tp]}
               onChange={() => setTypes({ ...types, [tp]: !types[tp] })}
             />
-            {t(tp)}
+            {typeLabels[tp]}
           </label>
         ))}
 
@@ -146,7 +134,7 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
             else next.add(tag);
             setTagSet(next);
           }}
-          label={t('tags')}
+          label={t.tags}
           className="ml-2"
         />
       </FilterBar>
@@ -156,7 +144,7 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
         if (!arr.length) return null;
         return (
           <section key={type} className="space-y-3">
-            <h2 className="text-xl font-semibold">{t(type)}</h2>
+            <h2 className="text-xl font-semibold">{typeLabels[type]}</h2>
             <ul className="space-y-3">
               {arr.map((i) => {
                 const primaryLink = i.links[0]?.url;
@@ -227,7 +215,7 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
       })}
 
       {order.every((t) => !(groups[t] || []).length) && (
-        <p className="opacity-70">{t('noResult')}</p>
+        <p className="opacity-70">{t.noResult}</p>
       )}
     </div>
   );

--- a/src/app/publications/sections/PublicationsClient.tsx
+++ b/src/app/publications/sections/PublicationsClient.tsx
@@ -113,17 +113,23 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
           label={t.year}
         />
 
-        <span className="text-sm opacity-70">{t.types}</span>
-        {order.map((tp) => (
-          <label key={tp} className="text-sm inline-flex items-center gap-1">
-            <input
-              type="checkbox"
-              checked={types[tp]}
-              onChange={() => setTypes({ ...types, [tp]: !types[tp] })}
-            />
-            {typeLabels[tp]}
-          </label>
-        ))}
+        <details className="ml-2">
+          <summary className="cursor-pointer select-none text-sm opacity-80">
+            {t.types} ({order.length})
+          </summary>
+          <div className="mt-2 flex flex-col gap-1">
+            {order.map((tp) => (
+              <label key={tp} className="text-sm inline-flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={types[tp]}
+                  onChange={() => setTypes({ ...types, [tp]: !types[tp] })}
+                />
+                {typeLabels[tp]}
+              </label>
+            ))}
+          </div>
+        </details>
 
         <TagSelector
           tags={allTags}

--- a/src/app/publications/sections/PublicationsClient.tsx
+++ b/src/app/publications/sections/PublicationsClient.tsx
@@ -2,6 +2,8 @@
 import { useMemo, useState, type KeyboardEvent } from 'react';
 import { withBasePath } from '@/lib/url';
 import { useSearchFilters } from '@/hooks/useSearchFilters';
+import { YearSelect } from '@/components/filters/YearSelect';
+import { TagSelector } from '@/components/filters/TagSelector';
 
 type Item = {
   slug: string;
@@ -113,11 +115,12 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
       />
 
       <div className="flex flex-wrap items-center gap-2">
-        <label className="text-sm opacity-70">{t('year')}</label>
-        <select value={year} onChange={(e)=>setYear(e.target.value)} className="border rounded-sm px-2 py-1 dark:border-gray-700">
-          <option value="">All</option>
-          {years.map((y)=> <option key={y} value={y}>{y}</option>)}
-        </select>
+        <YearSelect
+          years={years}
+          value={year}
+          onChange={setYear}
+          label={t('year')}
+        />
 
         <span className="text-sm opacity-70">{t('types')}</span>
         {order.map((tp) => (
@@ -131,30 +134,18 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
           </label>
         ))}
 
-        <details className="ml-2">
-          <summary className="cursor-pointer select-none text-sm opacity-80">
-            {t('tags')} ({allTags.length})
-          </summary>
-          <div className="mt-2 flex flex-wrap gap-2">
-            {allTags.map((tag) => {
-              const active = tagSet.has(tag);
-              return (
-                <button
-                  key={tag}
-                  onClick={() => {
-                    const next = new Set(tagSet);
-                    if (active) next.delete(tag);
-                    else next.add(tag);
-                    setTagSet(next);
-                  }}
-                  className={`px-2 py-0.5 rounded-sm text-sm border ${active ? 'bg-gray-200 dark:bg-gray-700' : ''}`}
-                >
-                  #{tag}
-                </button>
-              );
-            })}
-          </div>
-        </details>
+        <TagSelector
+          tags={allTags}
+          selected={tagSet}
+          onToggle={(tag) => {
+            const next = new Set(tagSet);
+            if (next.has(tag)) next.delete(tag);
+            else next.add(tag);
+            setTagSet(next);
+          }}
+          label={t('tags')}
+          className="ml-2"
+        />
 
         {(q || year || tagSet.size || Object.values(types).some(v=>!v)) ? (
           <button

--- a/src/components/filters/FilterBar.stories.tsx
+++ b/src/components/filters/FilterBar.stories.tsx
@@ -1,0 +1,66 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { FilterBar } from './FilterBar';
+import { YearSelect } from './YearSelect';
+import { TagSelector } from './TagSelector';
+import React, { useState } from 'react';
+
+const meta = {
+  title: 'Filters/FilterBar',
+  component: FilterBar,
+  parameters: {
+    layout: 'padded',
+  },
+  render: (args) => <FilterBarStory {...args} />,
+  args: {
+    placeholder: 'Search...',
+    clearLabel: 'Clear',
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof FilterBar>;
+
+function FilterBarStory(props: React.ComponentProps<typeof FilterBar>) {
+  const [query, setQuery] = useState('');
+  const [year, setYear] = useState('');
+  const [tagSet, setTagSet] = useState<Set<string>>(new Set());
+  const tags = ['nlp', 'ml', 'dev'];
+  const years = ['2025', '2024', '2023'];
+
+  return (
+    <FilterBar
+      {...props}
+      query={query}
+      onQueryChange={setQuery}
+      onClear={() => {
+        setQuery('');
+        setYear('');
+        setTagSet(new Set());
+      }}
+      hasActiveFilters={Boolean(year || tagSet.size)}
+    >
+      <YearSelect years={years} value={year} onChange={setYear} label="Year" />
+      <TagSelector
+        tags={tags}
+        selected={tagSet}
+        onToggle={(tag) => {
+          const next = new Set(tagSet);
+          if (next.has(tag)) next.delete(tag);
+          else next.add(tag);
+          setTagSet(next);
+        }}
+        label="Tags"
+      />
+    </FilterBar>
+  );
+}
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    query: '',
+    onQueryChange: () => {},
+    placeholder: 'Search...',
+    clearLabel: 'Clear',
+  },
+};

--- a/src/components/filters/FilterBar.tsx
+++ b/src/components/filters/FilterBar.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+
+type Props = {
+  query: string;
+  onQueryChange: (value: string) => void;
+  placeholder: string;
+  onClear?: () => void;
+  children?: React.ReactNode;
+  className?: string;
+  clearLabel?: string;
+  hasActiveFilters?: boolean;
+};
+
+export function FilterBar({
+  query,
+  onQueryChange,
+  placeholder,
+  onClear,
+  children,
+  className,
+  clearLabel = 'Clear',
+  hasActiveFilters,
+}: Props) {
+  const showClear = Boolean(hasActiveFilters) || Boolean(query);
+
+  return (
+    <div className={`flex flex-wrap items-center gap-3 ${className || ''}`}>
+      <input
+        aria-label={placeholder}
+        value={query}
+        onChange={(e) => onQueryChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full sm:w-auto flex-1 border rounded-sm px-3 py-2 dark:border-gray-700"
+      />
+
+      {children}
+
+      {showClear && onClear ? (
+        <button onClick={onClear} className="text-sm underline ml-auto">
+          {clearLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/filters/TagSelector.tsx
+++ b/src/components/filters/TagSelector.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+type Props = {
+  tags: string[];
+  selected: Set<string>;
+  onToggle: (tag: string) => void;
+  label: string;
+  className?: string;
+};
+
+export function TagSelector({ tags, selected, onToggle, label, className }: Props) {
+  return (
+    <details className={className}>
+      <summary className="cursor-pointer select-none text-sm opacity-80">
+        {label} ({tags.length})
+      </summary>
+      <div className="mt-2 flex flex-wrap gap-2">
+        {tags.map((tag) => {
+          const active = selected.has(tag);
+          return (
+            <button
+              key={tag}
+              onClick={() => onToggle(tag)}
+              className={`px-2 py-0.5 rounded-sm text-sm border ${active ? 'bg-gray-200 dark:bg-gray-700' : ''}`}
+            >
+              #{tag}
+            </button>
+          );
+        })}
+      </div>
+    </details>
+  );
+}

--- a/src/components/filters/YearSelect.tsx
+++ b/src/components/filters/YearSelect.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+type Props = {
+  years: string[];
+  value: string;
+  onChange: (year: string) => void;
+  label: string;
+  allLabel?: string;
+  className?: string;
+};
+
+export function YearSelect({ years, value, onChange, label, allLabel = 'All', className }: Props) {
+  return (
+    <div className={className}>
+      <label className="text-sm opacity-70 mr-2">{label}</label>
+      <select
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="border rounded-sm px-2 py-1 dark:border-gray-700"
+      >
+        <option value="">{allLabel}</option>
+        {years.map((y) => (
+          <option key={y} value={y}>
+            {y}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/src/components/filters/filterTexts.ts
+++ b/src/components/filters/filterTexts.ts
@@ -1,0 +1,29 @@
+export type FilterTextKey = 'search' | 'latest' | 'allPosts' | 'noResult' | 'year' | 'tags' | 'clear' | 'types';
+
+export type FilterTextDict = Record<FilterTextKey, string>;
+
+export const filterTextJa: FilterTextDict = {
+  search: '検索...',
+  latest: '✨ 最新',
+  allPosts: '🗂 すべての記事',
+  noResult: '該当する項目がありません',
+  year: '年',
+  tags: 'タグ',
+  clear: 'クリア',
+  types: '種類',
+};
+
+export const filterTextEn: FilterTextDict = {
+  search: 'Search...',
+  latest: '✨ Latest',
+  allPosts: '🗂 All Posts',
+  noResult: 'No items found',
+  year: 'Year',
+  tags: 'Tags',
+  clear: 'Clear',
+  types: 'Types',
+};
+
+export function resolveFilterText(locale: 'ja' | 'en'): FilterTextDict {
+  return locale === 'ja' ? filterTextJa : filterTextEn;
+}

--- a/src/components/home/HomeContentView.tsx
+++ b/src/components/home/HomeContentView.tsx
@@ -34,9 +34,9 @@ export function HomeContentView({ locale, dict, latest, publications, links }: H
         title={dict.title}
         alias={dict.alias}
         handle={dict.handle}
-      affiliation={dict.affiliation}
-      intro={dict.intro}
-    />
+        affiliation={dict.affiliation}
+        intro={dict.intro}
+      />
 
       <LinksSection links={links} ctaLabel={dict.cta_more} />
 

--- a/src/components/home/sections/LinksSection.tsx
+++ b/src/components/home/sections/LinksSection.tsx
@@ -1,54 +1,18 @@
 import React from 'react';
-import clsx from 'clsx';
 import type { LinkItem } from '@/lib/data/links';
-import { ExternalIcon } from '@/components/ui/ExternalIcon';
 import { SectionHeader } from './SectionHeader';
+import { LinkGrid } from '@/components/links/LinkGrid';
 
 type Props = {
   links: LinkItem[];
   ctaLabel: string;
 };
 
-const MOBILE_PRIMARY = 3;
-
 export function LinksSection({ links, ctaLabel }: Props) {
-  const secondaryLinks = links.slice(MOBILE_PRIMARY);
-
-  const renderLinkItem = (key: string, item: LinkItem, className?: string) => (
-    <li key={key} className={clsx('text-center', className)}>
-      <a href={item.url} target="_blank" rel="noreferrer" className="inline-block">
-        {item.iconUrl ? (
-          <ExternalIcon src={item.iconUrl} alt={item.title} size={40} />
-        ) : (
-          <span className="inline-flex items-center justify-center w-10 h-10 rounded-full bg-gray-100 dark:bg-gray-800 text-sm">
-            {item.title.slice(0, 1)}
-          </span>
-        )}
-      </a>
-      <div className="text-xs mt-1 truncate">{item.title}</div>
-    </li>
-  );
-
   return (
     <section>
       <SectionHeader title="🔗 Links" ctaLabel={ctaLabel} ctaHref="/links/" />
-      <ul className="grid grid-cols-3 sm:grid-cols-6 gap-4">
-        {links.map((link, index) =>
-          renderLinkItem(
-            `primary-${link.url}`,
-            link,
-            index >= MOBILE_PRIMARY ? 'hidden sm:block' : undefined,
-          ),
-        )}
-      </ul>
-      {secondaryLinks.length ? (
-        <details className="sm:hidden mt-4">
-          <summary className="text-sm underline cursor-pointer">{ctaLabel}</summary>
-          <ul className="grid grid-cols-3 gap-4 mt-3">
-            {secondaryLinks.map((link) => renderLinkItem(`mobile-${link.url}`, link))}
-          </ul>
-        </details>
-      ) : null}
+      <LinkGrid items={links} moreLabel={ctaLabel} iconSize={40} />
     </section>
   );
 }

--- a/src/components/home/sections/ProfileSection.tsx
+++ b/src/components/home/sections/ProfileSection.tsx
@@ -1,6 +1,7 @@
-import React, { type ReactNode } from 'react';
+import React from 'react';
 import Link from 'next/link';
 import { withBasePath, withVersion } from '@/lib/url';
+import { renderInlineLinks } from '@/lib/ui/inlineMarkdown';
 
 type Props = {
   title: string;
@@ -13,32 +14,6 @@ type Props = {
 // シンプルなプロフィール表示セクション
 export function ProfileSection({ title, alias, handle, affiliation, intro }: Props) {
   const avatarSrc = withVersion(withBasePath('/favicon.ico'));
-
-  const renderAffiliation = (text: string): ReactNode => {
-    const nodes: ReactNode[] = [];
-    const pattern = /\[([^\]]+)\]\(([^)]+)\)/g;
-    let lastIndex = 0;
-    let match: RegExpExecArray | null;
-    let key = 0;
-    while ((match = pattern.exec(text))) {
-      const [full, label, url] = match;
-      if (match.index > lastIndex) nodes.push(text.slice(lastIndex, match.index));
-      nodes.push(
-        <a
-          key={`affiliation-link-${key++}`}
-          href={url}
-          target="_blank"
-          rel="noreferrer"
-          className="underline underline-offset-2 hover:no-underline"
-        >
-          {label}
-        </a>,
-      );
-      lastIndex = match.index + full.length;
-    }
-    if (lastIndex < text.length) nodes.push(text.slice(lastIndex));
-    return nodes.length ? nodes : text;
-  };
 
   return (
     <section className="flex flex-col gap-4">
@@ -58,7 +33,7 @@ export function ProfileSection({ title, alias, handle, affiliation, intro }: Pro
           <p className="text-sm text-gray-700 dark:text-gray-300 mt-1">{alias}</p>
           <p className="text-sm text-gray-700 dark:text-gray-300 mt-0">{handle}</p>
           {affiliation ? (
-            <p className="text-sm text-gray-700 dark:text-gray-300 mt-0">{renderAffiliation(affiliation)}</p>
+            <p className="text-sm text-gray-700 dark:text-gray-300 mt-0">{renderInlineLinks(affiliation)}</p>
           ) : null}
           <p className="text-sm mt-0">
             <Link

--- a/src/components/links/LinkGrid.stories.tsx
+++ b/src/components/links/LinkGrid.stories.tsx
@@ -1,28 +1,35 @@
 import type { Meta, StoryObj } from '@storybook/react';
-import { LinksSection } from './LinksSection';
+import { LinkGrid } from './LinkGrid';
 import { sampleLinks } from '@/stories/fixtures/links';
 
 const meta = {
-  title: 'Home/LinksSection',
-  component: LinksSection,
+  title: 'Links/LinkGrid',
+  component: LinkGrid,
   parameters: {
     layout: 'fullscreen',
   },
   args: {
-    links: sampleLinks,
-    ctaLabel: 'もっと見る',
+    items: sampleLinks,
+    moreLabel: 'さらに表示',
+    showDescription: true,
   },
-  tags: ['autodocs'],
   render: (args) => (
     <div className="bg-gray-50 dark:bg-gray-900 min-h-[260px]">
       <div className="container mx-auto max-w-4xl px-4 py-6">
-        <LinksSection {...args} />
+        <LinkGrid {...args} />
       </div>
     </div>
   ),
-} satisfies Meta<typeof LinksSection>;
+  tags: ['autodocs'],
+} satisfies Meta<typeof LinkGrid>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
+
+export const WithoutDescriptions: Story = {
+  args: {
+    showDescription: false,
+  },
+};

--- a/src/components/links/LinkGrid.tsx
+++ b/src/components/links/LinkGrid.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import clsx from 'clsx';
+import type { LinkItem } from '@/lib/data/links';
+import { LinkIcon } from '@/components/links/LinkIcon';
+
+type Props = {
+  items: LinkItem[];
+  mobileLimit?: number;
+  showDescription?: boolean;
+  moreLabel?: string;
+  iconSize?: number;
+  gridClassName?: string;
+};
+
+export function LinkGrid({ items, mobileLimit = 3, showDescription = false, moreLabel = 'See more', iconSize = 48, gridClassName = 'grid grid-cols-3 sm:grid-cols-6 gap-4' }: Props) {
+  const primary = items.slice(0, mobileLimit);
+  const secondary = items.slice(mobileLimit);
+
+  const renderItem = (key: string, item: LinkItem, extraClassName?: string) => (
+    <li key={key} className={clsx('text-center card p-4', extraClassName)}>
+      <a href={item.url} target="_blank" rel="noreferrer" className="inline-block mb-2">
+        <LinkIcon item={item} size={iconSize} />
+      </a>
+      <a
+        href={item.url}
+        target="_blank"
+        rel="noreferrer"
+        className="font-medium underline-offset-2 hover:underline block"
+      >
+        {item.title}
+      </a>
+      {showDescription && item.desc ? (
+        <p className="text-sm text-gray-600 dark:text-gray-300 mt-1">{item.desc}</p>
+      ) : null}
+    </li>
+  );
+
+  return (
+    <div className="space-y-3">
+      <ul className={gridClassName}>
+        {items.map((item, index) =>
+          renderItem(
+            `${item.url}-${index}`,
+            item,
+            index >= mobileLimit ? 'hidden sm:block' : undefined,
+          ),
+        )}
+      </ul>
+
+      {secondary.length ? (
+        <details className="sm:hidden">
+          <summary className="text-sm underline cursor-pointer">{moreLabel}</summary>
+          <ul className="grid grid-cols-3 gap-4 mt-3">
+            {secondary.map((item, index) => renderItem(`mobile-${item.url}-${index}`, item))}
+          </ul>
+        </details>
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/links/LinkIcon.tsx
+++ b/src/components/links/LinkIcon.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import type { LinkItem } from '@/lib/data/links';
+import { ExternalIcon } from '@/components/ui/ExternalIcon';
+
+type Props = {
+  item: LinkItem;
+  size?: number;
+  className?: string;
+};
+
+export function LinkIcon({ item, size = 48, className }: Props) {
+  if (item.iconUrl) {
+    return <ExternalIcon src={item.iconUrl} alt={item.title} size={size} className={className} />;
+  }
+  return (
+    <span
+      className={`inline-flex items-center justify-center rounded-full bg-gray-100 dark:bg-gray-800 text-sm ${className || ''}`}
+      style={{ width: size, height: size }}
+    >
+      {item.title.slice(0, 1)}
+    </span>
+  );
+}

--- a/src/components/site/Footer.tsx
+++ b/src/components/site/Footer.tsx
@@ -1,22 +1,10 @@
 "use client";
-import { useEffect, useState } from 'react';
-import { withBasePath } from '@/lib/url';
+import { absoluteUrl } from '@/lib/seo';
 
 export function Footer() {
-  const [sitemapHref, setSitemapHref] = useState(withBasePath('/sitemap.xml')!);
-  const [rssHref, setRssHref] = useState(withBasePath('/rss.xml')!);
-  const [robotsHref, setRobotsHref] = useState(withBasePath('/robots.txt')!);
-
-  useEffect(() => {
-    try {
-      const base = window.location.href;
-      setSitemapHref(new URL(withBasePath('/sitemap.xml')!, base).toString());
-      setRssHref(new URL(withBasePath('/rss.xml')!, base).toString());
-      setRobotsHref(new URL(withBasePath('/robots.txt')!, base).toString());
-    } catch {
-      // noop: keep SSR fallback
-    }
-  }, []);
+  const sitemapHref = absoluteUrl('/sitemap.xml');
+  const rssHref = absoluteUrl('/rss.xml');
+  const robotsHref = absoluteUrl('/robots.txt');
 
   return (
     <footer className="mt-12 border-t border-gray-200 dark:border-gray-800">

--- a/src/components/site/Header.tsx
+++ b/src/components/site/Header.tsx
@@ -3,21 +3,23 @@ import Link from 'next/link';
 import { ThemeToggle } from '@/components/site/ThemeToggle';
 import { LanguageSwitch } from '@/components/site/LanguageSwitch';
 import { usePathname } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { NavLinks } from '@/components/site/NavLinks';
 import { MobileMenu } from '@/components/site/MobileMenu';
 import { NAV_ITEMS } from '@/components/site/navItems';
+import { extractLocaleFromPath, localizedPath } from '@/lib/routing';
 
 export function Header() {
   const pathname = usePathname() || '';
   const [open, setOpen] = useState(false);
-  const localePrefix = pathname.startsWith('/ja') ? '/ja' : pathname.startsWith('/en') ? '/en' : '';
+  const locale = extractLocaleFromPath(pathname) || 'ja';
+  const localePrefix = locale === 'ja' ? '/ja' : '/en';
   const activePath = pathname;
 
   // メニュー表示中はスクロールを固定
   useEffect(() => {
     if (typeof document === 'undefined') return;
-    const root = document.documentElement;
+    const root = document.body;
     if (open) {
       root.style.overflow = 'hidden';
     } else {
@@ -28,12 +30,12 @@ export function Header() {
     };
   }, [open]);
 
-  const navItems = useMemo(() => NAV_ITEMS, []);
+  const navItems = NAV_ITEMS;
 
   return (
     <header className="sticky top-0 z-40 bg-white/70 dark:bg-gray-900/70 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">
       <div className="container mx-auto max-w-4xl px-4 py-4 flex items-center justify-between">
-        <Link href="/" className="font-semibold text-lg">Tatsuki Okada - Personal Site</Link>
+        <Link href={localizedPath('/', locale)} className="font-semibold text-lg">Tatsuki Okada - Personal Site</Link>
         {/* Desktop nav */}
         <div className="hidden sm:flex items-center gap-4">
           <NavLinks items={navItems} activePath={activePath} localePrefix={localePrefix} />

--- a/src/components/site/Header.tsx
+++ b/src/components/site/Header.tsx
@@ -6,7 +6,7 @@ import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { NavLinks } from '@/components/site/NavLinks';
 import { MobileMenu } from '@/components/site/MobileMenu';
-import { NAV_ITEMS } from '@/components/site/navItems';
+import { resolveNavItems } from '@/components/site/navItems';
 import { extractLocaleFromPath, localizedPath } from '@/lib/routing';
 
 export function Header() {
@@ -30,7 +30,7 @@ export function Header() {
     };
   }, [open]);
 
-  const navItems = NAV_ITEMS;
+  const navItems = resolveNavItems(locale);
 
   return (
     <header className="sticky top-0 z-40 bg-white/70 dark:bg-gray-900/70 backdrop-blur-sm border-b border-gray-200 dark:border-gray-800">

--- a/src/components/site/LanguageSwitch.tsx
+++ b/src/components/site/LanguageSwitch.tsx
@@ -1,31 +1,26 @@
 "use client";
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { extractLocaleFromPath, isTranslatablePath, localizedPath, stripLocalePrefix } from '@/lib/routing';
 
 // 簡易実装: トップのみja/enを切替（他ページは言語非対応）
 export function LanguageSwitch() {
   const pathname = usePathname() || '';
 
-  // 対応ページ: /, /links, /publications, /blogs（ロケール有無）
-  const translatable = (p: string) => {
-    if (!p) return false;
-    if (p === '/' || p === '/ja/' || p === '/en/') return true;
-    const bare = p.replace(/^\/(ja|en)/, '');
-    return ['/', '/links/', '/publications/', '/blogs/'].includes(bare.endsWith('/') ? bare : bare + '/');
-  };
-
-  if (!translatable(pathname)) {
+  if (!isTranslatablePath(pathname)) {
     return <span className="text-sm opacity-60">JA/EN</span>;
   }
 
-  const rest = pathname.replace(/^\/(ja|en)/, '');
-  const toJa = rest === '/' ? '/ja/' : `/ja${rest.endsWith('/') ? rest : rest + '/'}`;
-  const toEn = rest === '/' ? '/en/' : `/en${rest.endsWith('/') ? rest : rest + '/'}`;
+  const currentLocale = extractLocaleFromPath(pathname) || 'ja';
+  const bare = stripLocalePrefix(pathname);
+  const normalized = bare.endsWith('/') ? bare : `${bare}/`;
+  const toJa = localizedPath(normalized, 'ja');
+  const toEn = localizedPath(normalized, 'en');
 
   return (
     <span className="text-sm">
-      <Link href={toJa} className="mr-1 underline">JA</Link>/
-      <Link href={toEn} className="ml-1 underline">EN</Link>
+      <Link href={toJa} className="mr-1 underline" aria-current={currentLocale === 'ja' ? 'true' : undefined}>JA</Link>/
+      <Link href={toEn} className="ml-1 underline" aria-current={currentLocale === 'en' ? 'true' : undefined}>EN</Link>
     </span>
   );
 }

--- a/src/components/site/MobileMenu.stories.tsx
+++ b/src/components/site/MobileMenu.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { MobileMenu } from './MobileMenu';
-import { NAV_ITEMS } from './navItems';
+import { resolveNavItems } from './navItems';
 
 const meta = {
   title: 'Site/MobileMenu',
@@ -10,7 +10,7 @@ const meta = {
   },
   args: {
     open: true,
-    items: NAV_ITEMS,
+    items: resolveNavItems('ja'),
     activePath: '/',
     localePrefix: '',
     onClose: () => {},

--- a/src/components/site/MobileMenu.tsx
+++ b/src/components/site/MobileMenu.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { createPortal } from 'react-dom';
-import type { NavItem } from '@/components/site/navItems';
+import type { NavDisplayItem } from '@/components/site/navItems';
 import { NavLinks } from '@/components/site/NavLinks';
 
 type Props = {
   open: boolean;
   onClose: () => void;
-  items: NavItem[];
+  items: NavDisplayItem[];
   activePath: string;
   localePrefix: string;
 };
@@ -51,4 +51,3 @@ export function MobileMenu({ open, onClose, items, activePath, localePrefix }: P
     document.body,
   );
 }
-

--- a/src/components/site/NavLinks.stories.tsx
+++ b/src/components/site/NavLinks.stories.tsx
@@ -1,12 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import { NavLinks } from './NavLinks';
-import { NAV_ITEMS } from './navItems';
+import { resolveNavItems } from './navItems';
 
 const meta = {
   title: 'Site/NavLinks',
   component: NavLinks,
   args: {
-    items: NAV_ITEMS,
+    items: resolveNavItems('ja'),
     activePath: '/',
     localePrefix: '',
   },

--- a/src/components/site/NavLinks.tsx
+++ b/src/components/site/NavLinks.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Link from 'next/link';
 import clsx from 'clsx';
 import type { NavItem } from '@/components/site/navItems';
+import { extractLocaleFromPath, localizedPath, stripLocalePrefix } from '@/lib/routing';
 
 type Props = {
   items: NavItem[];
@@ -12,7 +13,9 @@ type Props = {
 };
 
 export function NavLinks({ items, activePath, localePrefix, orientation = 'horizontal', onNavigate }: Props) {
-  const isActive = (href: string) => activePath === `${localePrefix}${href}`;
+  const locale = extractLocaleFromPath(activePath) || (localePrefix === '/en' ? 'en' : null);
+  const normalizedActive = stripLocalePrefix(activePath.endsWith('/') ? activePath : `${activePath}/`);
+  const isActive = (href: string) => normalizedActive === (href.endsWith('/') ? href : `${href}/`);
 
   const baseClass = orientation === 'horizontal'
     ? 'px-2 py-1 rounded-sm hover:bg-gray-100 dark:hover:bg-gray-800'
@@ -23,7 +26,7 @@ export function NavLinks({ items, activePath, localePrefix, orientation = 'horiz
       {items.map((n) => (
         <Link
           key={n.href}
-          href={`${localePrefix}${n.href}`}
+          href={locale ? localizedPath(n.href, locale) : n.href}
           onClick={onNavigate}
           className={clsx(baseClass, isActive(n.href) && 'bg-gray-100 dark:bg-gray-800')}
         >
@@ -33,4 +36,3 @@ export function NavLinks({ items, activePath, localePrefix, orientation = 'horiz
     </nav>
   );
 }
-

--- a/src/components/site/NavLinks.tsx
+++ b/src/components/site/NavLinks.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import Link from 'next/link';
 import clsx from 'clsx';
-import type { NavItem } from '@/components/site/navItems';
+import type { NavDisplayItem } from '@/components/site/navItems';
 import { extractLocaleFromPath, localizedPath, stripLocalePrefix } from '@/lib/routing';
 
 type Props = {
-  items: NavItem[];
+  items: NavDisplayItem[];
   activePath: string;
   localePrefix: string;
   orientation?: 'horizontal' | 'vertical';

--- a/src/components/site/navItems.ts
+++ b/src/components/site/navItems.ts
@@ -1,9 +1,15 @@
-export type NavItem = { href: string; label: string };
+import type { Locale } from '@/lib/i18n';
 
-export const NAV_ITEMS: NavItem[] = [
-  { href: '/', label: '🏠 Home' },
-  { href: '/links/', label: '🔗 Links' },
-  { href: '/publications/', label: '📚 Publications' },
-  { href: '/blogs/', label: '📝 Blog' },
+export type NavItemDef = { href: string; label: Record<Locale, string> };
+export type NavDisplayItem = { href: string; label: string };
+
+const NAV_ITEMS: NavItemDef[] = [
+  { href: '/', label: { ja: '🏠 Home', en: '🏠 Home' } },
+  { href: '/links/', label: { ja: '🔗 Links', en: '🔗 Links' } },
+  { href: '/publications/', label: { ja: '📚 Publications', en: '📚 Publications' } },
+  { href: '/blogs/', label: { ja: '📝 Blog', en: '📝 Blog' } },
 ];
 
+export function resolveNavItems(locale: Locale): NavDisplayItem[] {
+  return NAV_ITEMS.map((item) => ({ href: item.href, label: item.label[locale] }));
+}

--- a/src/hooks/useSearchFilters.ts
+++ b/src/hooks/useSearchFilters.ts
@@ -1,0 +1,57 @@
+import { useMemo, useState } from 'react';
+import Fuse from 'fuse.js';
+
+type Options<T> = {
+  fuseKeys: string[];
+  threshold?: number;
+  extractYear: (item: T) => string | undefined;
+  extractTags: (item: T) => string[];
+};
+
+export function useSearchFilters<T>(items: T[], { fuseKeys, threshold = 0.35, extractYear, extractTags }: Options<T>) {
+  const [q, setQ] = useState('');
+  const [year, setYear] = useState('');
+  const [tagSet, setTagSet] = useState<Set<string>>(new Set());
+
+  const fuse = useMemo(() => new Fuse(items, { keys: fuseKeys, threshold }), [items, fuseKeys, threshold]);
+
+  const years = useMemo(
+    () =>
+      Array.from(new Set(items.map((item) => (extractYear(item) || '').slice(0, 4))))
+        .filter(Boolean)
+        .sort((a, b) => (a < b ? 1 : -1)),
+    [items, extractYear],
+  );
+
+  const allTags = useMemo(
+    () => Array.from(new Set(items.flatMap((item) => extractTags(item)))).sort(),
+    [items, extractTags],
+  );
+
+  const filtered = useMemo(() => {
+    let result = q ? fuse.search(q).map((r) => r.item) : items;
+    if (year) result = result.filter((item) => (extractYear(item) || '').startsWith(year));
+    if (tagSet.size) result = result.filter((item) => extractTags(item).some((tag) => tagSet.has(tag)));
+    return result;
+  }, [items, fuse, q, year, tagSet, extractYear, extractTags]);
+
+  const clearFilters = () => {
+    setQ('');
+    setYear('');
+    setTagSet(new Set());
+  };
+
+  return {
+    q,
+    setQ,
+    year,
+    setYear,
+    tagSet,
+    setTagSet,
+    fuse,
+    years,
+    allTags,
+    filtered,
+    clearFilters,
+  };
+}

--- a/src/lib/content/blog.ts
+++ b/src/lib/content/blog.ts
@@ -1,9 +1,9 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
 import { shouldIncludeDrafts } from '@/lib/config/env';
-import { cached } from '@/lib/server/cache';
 import { BlogFrontmatter } from './types';
 import { parseMarkdownFile, slugFromFilename } from './markdown';
+import { loadCollection } from './loader';
+import { cached } from '@/lib/server/cache';
 
 const BLOG_DIR = path.join(process.cwd(), 'src', 'content', 'blogs');
 
@@ -25,34 +25,29 @@ export type BlogPost = {
 export async function getAllPosts(): Promise<BlogPost[]> {
   const includeDrafts = shouldIncludeDrafts();
   const cacheKey = `blog:all:${includeDrafts ? 'drafts' : 'public'}`;
-  return cached(cacheKey, async () => {
-    const files = await fs.readdir(BLOG_DIR);
-    const mdFiles = files.filter((f) => f.endsWith('.md'));
-    const posts = await Promise.all<BlogPost | null>(
-      mdFiles.map(async (filename) => {
-        const full = path.join(BLOG_DIR, filename);
-        const { data } = await parseMarkdownFile(full);
-        const parsed = BlogFrontmatter.safeParse(data);
-        if (!parsed.success) return null;
-        const fm = parsed.data;
-        if (fm.draft && !includeDrafts) return null;
-        return {
-          slug: slugFromFilename(filename),
-          title: fm.title,
-          date: fm.date,
-          updated: fm.updated,
-          tags: fm.tags,
-          summary: fm.summary || '',
-          thumbnail: fm.thumbnail,
-          headerImage: fm.headerImage,
-          headerAlt: fm.headerAlt,
-          draft: fm.draft,
-        } satisfies BlogPost;
-      }),
-    );
-    const list: BlogPost[] = posts.filter((p): p is BlogPost => p !== null);
-    list.sort((a, b) => (a.date < b.date ? 1 : -1));
-    return list;
+  return loadCollection<BlogPost>({
+    dir: BLOG_DIR,
+    cacheKey,
+    parse: async (full, filename) => {
+      const { data } = await parseMarkdownFile(full);
+      const parsed = BlogFrontmatter.safeParse(data);
+      if (!parsed.success) return null;
+      const fm = parsed.data;
+      if (fm.draft && !includeDrafts) return null;
+      return {
+        slug: slugFromFilename(filename),
+        title: fm.title,
+        date: fm.date,
+        updated: fm.updated,
+        tags: fm.tags,
+        summary: fm.summary || '',
+        thumbnail: fm.thumbnail,
+        headerImage: fm.headerImage,
+        headerAlt: fm.headerAlt,
+        draft: fm.draft,
+      } satisfies BlogPost;
+    },
+    sort: (a, b) => (a.date < b.date ? 1 : -1),
   });
 }
 

--- a/src/lib/content/loader.ts
+++ b/src/lib/content/loader.ts
@@ -1,0 +1,28 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { cached } from '@/lib/server/cache';
+
+type LoaderOptions<T> = {
+  dir: string;
+  cacheKey: string;
+  exts?: string[];
+  parse: (fullPath: string, filename: string) => Promise<T | null>;
+  sort?: (a: T, b: T) => number;
+};
+
+export async function loadCollection<T>({ dir, cacheKey, exts = ['.md', '.mdx'], parse, sort }: LoaderOptions<T>) {
+  return cached(cacheKey, async () => {
+    const files = await fs.readdir(dir);
+    const filtered = files.filter((f) => exts.includes(path.extname(f)));
+    const items: T[] = [];
+    for (const filename of filtered) {
+      const full = path.join(dir, filename);
+      const parsed = await parse(full, filename);
+      if (parsed) items.push(parsed);
+    }
+    if (sort) {
+      items.sort(sort);
+    }
+    return items;
+  });
+}

--- a/src/lib/content/og/cache.ts
+++ b/src/lib/content/og/cache.ts
@@ -1,0 +1,36 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { OGData } from './types';
+
+export async function readCache(file: string): Promise<Record<string, OGData>> {
+  try {
+    const raw = await fs.readFile(file, 'utf8');
+    return JSON.parse(raw);
+  } catch {
+    return {};
+  }
+}
+
+export async function writeCache(file: string, data: Record<string, OGData>) {
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  await fs.writeFile(file, JSON.stringify(data, null, 2), 'utf8');
+}
+
+export function isFresh(entry: OGData | undefined, ttlMs: number): boolean {
+  if (!entry?.fetchedAt) return false;
+  return Date.now() - entry.fetchedAt < ttlMs;
+}
+
+export function hasPreview(entry: OGData | null | undefined): boolean {
+  return !!(entry && (entry.title || entry.image || entry.description || entry.siteName));
+}
+
+export function upsertCache(cache: Record<string, OGData>, url: string, data: OGData): boolean {
+  const prev = cache[url];
+  const same = prev && JSON.stringify(prev) === JSON.stringify(data);
+  if (!same) {
+    cache[url] = data;
+    return true;
+  }
+  return false;
+}

--- a/src/lib/content/og/fetch.ts
+++ b/src/lib/content/og/fetch.ts
@@ -1,0 +1,126 @@
+import { getOgCacheTtlMs, shouldDisableOgFetch } from '@/lib/config/env';
+import type { OGData } from './types';
+import { providerFallback } from './provider';
+
+async function fetchProviderMeta(url: string): Promise<OGData | null> {
+  try {
+    const u = new URL(url);
+    // YouTube oEmbed
+    if (u.hostname === 'youtu.be' || u.hostname.endsWith('youtube.com')) {
+      let canonical = url;
+      if (u.hostname === 'youtu.be') {
+        const id = u.pathname.slice(1);
+        canonical = `https://www.youtube.com/watch?v=${id}`;
+      }
+      const o = await fetch(`https://www.youtube.com/oembed?format=json&url=${encodeURIComponent(canonical)}`);
+      if (o.ok) {
+        const j: any = await o.json();
+        return { url, title: j.title, image: j.thumbnail_url, siteName: 'YouTube' };
+      }
+    }
+    // X (Twitter) oEmbed（publish.twitter.com）
+    if (u.hostname === 'x.com' || u.hostname === 'twitter.com') {
+      const canonical = `https://twitter.com${u.pathname}`;
+      const o = await fetch(`https://publish.twitter.com/oembed?omit_script=1&hide_thread=1&align=left&url=${encodeURIComponent(canonical)}`);
+      if (o.ok) {
+        const j: any = await o.json();
+        const html: string = j.html || '';
+        const p = html.match(/<p[^>]*>([\s\S]*?)<\/p>/i)?.[1] || '';
+        const text = p
+          .replace(/<br\s*\/>/gi, '\n')
+          .replace(/<[^>]+>/g, '')
+          .replace(/&amp;/g, '&')
+          .replace(/&lt;/g, '<')
+          .replace(/&gt;/g, '>')
+          .replace(/&quot;/g, '"')
+          .replace(/&#39;/g, "'")
+          .trim();
+        return { url, title: text || j.author_name || 'Tweet', siteName: 'X (Twitter)' };
+      }
+      return null;
+    }
+  } catch {}
+  return null;
+}
+
+export async function fetchOG(url: string): Promise<OGData | null> {
+  if (shouldDisableOgFetch()) {
+    return { url };
+  }
+  try {
+    // まずはプロバイダ専用の取得
+    const provider = await fetchProviderMeta(url);
+    if (provider) return { ...provider, fetchedAt: Date.now() };
+
+    const res = await fetch(url, {
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
+        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'ja-JP,ja;q=0.9,en-US;q=0.8,en;q=0.7',
+      },
+      redirect: 'follow',
+    });
+    if (!res.ok) return providerFallback(url) || { url };
+    const text = await res.text();
+    const head = text.slice(0, 500_000);
+    const data = extractMeta(head, url);
+    // Amazon: 本文の productTitle を補助的に利用
+    try {
+      const u = new URL(url);
+      if (/amazon\.(co\.jp|com)$|amzn\.to$/.test(u.hostname)) {
+        if (!data.title) {
+          const m = text.match(/<span[^>]*id=['"]productTitle['"][^>]*>([\s\S]*?)<\/span>/i);
+          const t = m ? m[1].replace(/\s+/g, ' ').trim() : '';
+          if (t) data.title = t;
+        }
+        data.siteName = data.siteName || 'Amazon';
+      }
+    } catch {}
+    data.fetchedAt = Date.now();
+    const hasAny = !!(data.title || data.image || data.description || data.siteName);
+    return hasAny ? data : providerFallback(url) || data;
+  } catch {
+    // Provider専用フォールバック（ネットワーク不可/OGなし）
+    return providerFallback(url);
+  }
+}
+
+function extractMeta(html: string, url: string): OGData {
+  const metaRe = /<meta\s+[^>]*>/gi;
+  const attrRe = /(\w[\w:-]*)\s*=\s*(["'])(.*?)\2/gi;
+  const map: Record<string, string> = {};
+  const tags = html.match(metaRe) || [];
+  for (const tag of tags) {
+    let m: RegExpExecArray | null;
+    let name: string | undefined;
+    let content: string | undefined;
+    while ((m = attrRe.exec(tag))) {
+      const key = m[1].toLowerCase();
+      const val = m[3];
+      if (key === 'property' || key === 'name') name = val.toLowerCase();
+      if (key === 'content') content = val;
+    }
+    if (name && content) {
+      map[name] = content;
+    }
+  }
+  const pick = (...keys: string[]) => {
+    for (const k of keys) {
+      if (map[k]) return map[k];
+    }
+    return undefined;
+  };
+  const data: OGData = {
+    url,
+    title: pick('og:title', 'twitter:title'),
+    description: pick('og:description', 'twitter:description'),
+    image: pick('og:image', 'twitter:image', 'twitter:image:src'),
+    siteName: pick('og:site_name', 'twitter:site', 'twitter:domain'),
+  };
+  return data;
+}
+
+export function ogTtlMs(defaultTtl = getOgCacheTtlMs()): number {
+  return defaultTtl;
+}

--- a/src/lib/content/og/provider.ts
+++ b/src/lib/content/og/provider.ts
@@ -1,0 +1,86 @@
+import type { OGData } from './types';
+
+export type Provider = 'youtube' | 'twitter' | 'instagram' | 'other';
+
+export function providerOf(u: string): Provider {
+  try {
+    const x = new URL(u);
+    if (x.hostname === 'youtu.be' || x.hostname.endsWith('youtube.com')) return 'youtube';
+    if (x.hostname === 'x.com' || x.hostname === 'twitter.com') return 'twitter';
+    if (x.hostname.endsWith('instagram.com')) return 'instagram';
+  } catch {}
+  return 'other';
+}
+
+export function ytIdFrom(u: string): string {
+  try {
+    const x = new URL(u);
+    if (x.hostname === 'youtu.be') return x.pathname.slice(1);
+    if (x.hostname.endsWith('youtube.com')) {
+      if (x.pathname.startsWith('/watch')) return x.searchParams.get('v') || '';
+      if (x.pathname.startsWith('/shorts/')) return x.pathname.split('/')[2] || '';
+    }
+  } catch {}
+  return '';
+}
+
+export function providerFallback(url: string): OGData | null {
+  try {
+    const u = new URL(url);
+    // X (Twitter)
+    if (u.hostname === 'x.com' || u.hostname === 'twitter.com') {
+      const m = u.pathname.match(/^\/(?:i\/web|home)?\/?([^\/]+)\/status\/(\d+)/);
+      const user = m?.[1];
+      return { url, title: user ? `Tweet by @${user}` : 'Tweet', siteName: 'X (Twitter)' };
+    }
+    // YouTube
+    if (u.hostname === 'youtu.be' || u.hostname.endsWith('youtube.com')) {
+      let id = '';
+      if (u.hostname === 'youtu.be') id = u.pathname.slice(1);
+      else if (u.pathname.startsWith('/watch')) id = u.searchParams.get('v') || '';
+      else if (u.pathname.startsWith('/shorts/')) id = u.pathname.split('/')[2] || '';
+      if (id) {
+        return {
+          url,
+          title: 'YouTube Video',
+          siteName: 'YouTube',
+          image: `https://i.ytimg.com/vi/${id}/hqdefault.jpg`,
+        };
+      }
+      return { url, siteName: 'YouTube' };
+    }
+    // Amazon (JP/Global)
+    if (
+      u.hostname.endsWith('amazon.co.jp') ||
+      u.hostname.endsWith('amazon.com') ||
+      u.hostname === 'amzn.to'
+    ) {
+      const asinMatch = u.pathname.match(/\/dp\/([A-Z0-9]{10})/i);
+      const asin = asinMatch?.[1];
+      return { url, title: asin ? `Amazon: ${asin}` : undefined, siteName: 'Amazon' };
+    }
+  } catch {}
+  return null;
+}
+
+export function embedHtmlFor(provider: Provider, url: string): string | null {
+  if (provider === 'youtube') {
+    const id = ytIdFrom(url);
+    if (!id) return null;
+    const canonical = `https://www.youtube.com/watch?v=${id}`;
+    return `<div class="rse-embed embed-video embed-youtube" data-provider="youtube" data-url="${canonical}"></div>`;
+  }
+  if (provider === 'twitter') {
+    try {
+      const x = new URL(url);
+      const canonical = x.hostname === 'twitter.com' ? url : `https://twitter.com${x.pathname}`;
+      return `<div class="rse-embed embed-social embed-twitter" data-provider="twitter" data-url="${canonical}"></div>`;
+    } catch {
+      return `<div class="rse-embed embed-social embed-twitter" data-provider="twitter" data-url="${url}"></div>`;
+    }
+  }
+  if (provider === 'instagram') {
+    return `<div class="rse-embed embed-social embed-instagram" data-provider="instagram" data-url="${url}"></div>`;
+  }
+  return null;
+}

--- a/src/lib/content/og/template.ts
+++ b/src/lib/content/og/template.ts
@@ -1,0 +1,55 @@
+import type { OGData } from './types';
+
+function escapeHtml(s: string) {
+  return s
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function prettyUrl(u: string): string {
+  try {
+    const x = new URL(u);
+    let pathname = x.pathname;
+    if (/amazon\.(co\.jp|com)$|amzn\.to$/.test(x.hostname)) {
+      const m = pathname.match(/\/dp\/[A-Z0-9]{10}/i);
+      pathname = m ? m[0] : pathname;
+    }
+    return `${x.hostname}${pathname}`;
+  } catch {
+    return u;
+  }
+}
+
+export function makeCardHTML(u: string, og: OGData | null) {
+  const host = (() => {
+    try {
+      return new URL(u).hostname;
+    } catch {
+      return u;
+    }
+  })();
+  const title = og?.title || u;
+  const desc = og?.description || '';
+  const img = og?.image || '';
+  const site = og?.siteName || host;
+  const esc = (s?: string) => (s ? escapeHtml(s) : '');
+  const noimg = !img;
+  const imgTag = img
+    ? `<div class="og-card__thumb"><img src="${esc(img)}" alt="" loading="lazy" referrerpolicy="no-referrer" /></div>`
+    : '';
+  const urlText = prettyUrl(u);
+  return (
+    `<a class="og-card card ${noimg ? 'og-card--noimg' : ''}" href="${esc(u)}" target="_blank" rel="noopener noreferrer">
+      ${imgTag}
+      <div class="og-card__body">
+        <div class="og-card__site">${esc(site)}</div>
+        <div class="og-card__title">${esc(title)}</div>
+        ${desc ? `<div class=\"og-card__desc\">${esc(desc)}</div>` : ''}
+        <div class="og-card__url">${esc(urlText)}</div>
+      </div>
+    </a>`
+  );
+}

--- a/src/lib/content/og/types.ts
+++ b/src/lib/content/og/types.ts
@@ -1,0 +1,8 @@
+export type OGData = {
+  url: string;
+  title?: string;
+  description?: string;
+  image?: string;
+  siteName?: string;
+  fetchedAt?: number;
+};

--- a/src/lib/content/publication.ts
+++ b/src/lib/content/publication.ts
@@ -1,27 +1,24 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import matter from 'gray-matter';
-import { cached } from '@/lib/server/cache';
 import { PublicationFrontmatter } from './types';
+import { loadCollection } from './loader';
 
 const PUB_DIR = path.join(process.cwd(), 'src', 'content', 'publications');
 
 export type Publication = PublicationFrontmatter & { slug: string };
 
 export async function getAllPublications(): Promise<Publication[]> {
-  return cached('publications:all', async () => {
-    const files = await fs.readdir(PUB_DIR);
-    const mdFiles = files.filter((f) => f.endsWith('.md'));
-    const items: Publication[] = [];
-    for (const f of mdFiles) {
-      const full = path.join(PUB_DIR, f);
+  return loadCollection<Publication>({
+    dir: PUB_DIR,
+    cacheKey: 'publications:all',
+    parse: async (full, filename) => {
       const raw = await fs.readFile(full, 'utf8');
       const { data } = matter(raw);
       const parsed = PublicationFrontmatter.safeParse(data);
-      if (!parsed.success) continue;
-      items.push({ ...parsed.data, slug: f.replace(/\.md$/, '') });
-    }
-    items.sort((a, b) => ((a.publishedAt || '') < (b.publishedAt || '') ? 1 : -1));
-    return items;
+      if (!parsed.success) return null;
+      return { ...parsed.data, slug: filename.replace(/\.mdx?$/, '') };
+    },
+    sort: (a, b) => ((a.publishedAt || '') < (b.publishedAt || '') ? 1 : -1),
   });
 }

--- a/src/lib/content/remark-link-card.ts
+++ b/src/lib/content/remark-link-card.ts
@@ -1,15 +1,10 @@
-import fs from 'node:fs/promises';
 import path from 'node:path';
-import { getOgCacheTtlMs, shouldDisableOgFetch } from '@/lib/config/env';
-
-type OGData = {
-  url: string;
-  title?: string;
-  description?: string;
-  image?: string;
-  siteName?: string;
-  fetchedAt?: number;
-};
+import { getOgCacheTtlMs } from '@/lib/config/env';
+import { fetchOG } from './og/fetch';
+import { hasPreview, isFresh, readCache, upsertCache, writeCache } from './og/cache';
+import { embedHtmlFor, providerOf } from './og/provider';
+import { makeCardHTML } from './og/template';
+import type { OGData } from './og/types';
 
 type Options = {
   allowDomains?: string[]; // 指定時は許可リスト方式。未指定なら自動判定（OG/Twitter Cardがあるときのみカード化）
@@ -19,247 +14,6 @@ type Options = {
 
 const DEFAULT_CACHE = path.join(process.cwd(), 'src', 'data', 'og-cache.json');
 
-function escapeHtml(s: string) {
-  return s
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&#39;');
-}
-
-function prettyUrl(u: string): string {
-  try {
-    const x = new URL(u);
-    let pathname = x.pathname;
-    if (/amazon\.(co\.jp|com)$|amzn\.to$/.test(x.hostname)) {
-      const m = pathname.match(/\/dp\/[A-Z0-9]{10}/i);
-      pathname = m ? m[0] : pathname;
-    }
-    return `${x.hostname}${pathname}`;
-  } catch {
-    return u;
-  }
-}
-
-async function readCache(file: string): Promise<Record<string, OGData>> {
-  try {
-    const raw = await fs.readFile(file, 'utf8');
-    return JSON.parse(raw);
-  } catch {
-    return {};
-  }
-}
-
-async function writeCache(file: string, data: Record<string, OGData>) {
-  await fs.mkdir(path.dirname(file), { recursive: true });
-  await fs.writeFile(file, JSON.stringify(data, null, 2), 'utf8');
-}
-
-// Extract meta tags from HTML head, attribute-order agnostic
-function extractMeta(html: string, url: string): OGData {
-  const metaRe = /<meta\s+[^>]*>/gi;
-  const attrRe = /(\w[\w:-]*)\s*=\s*(["'])(.*?)\2/gi;
-  const map: Record<string, string> = {};
-  const tags = html.match(metaRe) || [];
-  for (const tag of tags) {
-    let m: RegExpExecArray | null;
-    let name: string | undefined;
-    let content: string | undefined;
-    while ((m = attrRe.exec(tag))) {
-      const key = m[1].toLowerCase();
-      const val = m[3];
-      if (key === 'property' || key === 'name') name = val.toLowerCase();
-      if (key === 'content') content = val;
-    }
-    if (name && content) {
-      map[name] = content;
-    }
-  }
-  const pick = (...keys: string[]) => {
-    for (const k of keys) {
-      if (map[k]) return map[k];
-    }
-    return undefined;
-  };
-  const data: OGData = {
-    url,
-    title: pick('og:title', 'twitter:title'),
-    description: pick('og:description', 'twitter:description'),
-    image: pick('og:image', 'twitter:image', 'twitter:image:src'),
-    siteName: pick('og:site_name', 'twitter:site', 'twitter:domain'),
-  };
-  return data;
-}
-
-function providerFallback(url: string): OGData | null {
-  try {
-    const u = new URL(url);
-    // X (Twitter)
-    if (u.hostname === 'x.com' || u.hostname === 'twitter.com') {
-      const m = u.pathname.match(/^\/(?:i\/web|home)?\/?([^\/]+)\/status\/(\d+)/);
-      const user = m?.[1];
-      return { url, title: user ? `Tweet by @${user}` : 'Tweet', siteName: 'X (Twitter)' };
-    }
-    // YouTube
-    if (u.hostname === 'youtu.be' || u.hostname.endsWith('youtube.com')) {
-      let id = '';
-      if (u.hostname === 'youtu.be') id = u.pathname.slice(1);
-      else if (u.pathname.startsWith('/watch')) id = u.searchParams.get('v') || '';
-      else if (u.pathname.startsWith('/shorts/')) id = u.pathname.split('/')[2] || '';
-      if (id) {
-        return {
-          url,
-          title: 'YouTube Video',
-          siteName: 'YouTube',
-          image: `https://i.ytimg.com/vi/${id}/hqdefault.jpg`,
-        };
-      }
-      return { url, siteName: 'YouTube' };
-    }
-    // Amazon (JP/Global)
-    if (
-      u.hostname.endsWith('amazon.co.jp') ||
-      u.hostname.endsWith('amazon.com') ||
-      u.hostname === 'amzn.to'
-    ) {
-      const asinMatch = u.pathname.match(/\/dp\/([A-Z0-9]{10})/i);
-      const asin = asinMatch?.[1];
-      // 画像URLは安定しないため付けない
-      return { url, title: asin ? `Amazon: ${asin}` : undefined, siteName: 'Amazon' };
-    }
-  } catch {}
-  return null;
-}
-
-type Provider = 'youtube' | 'twitter' | 'instagram' | 'other';
-
-function providerOf(u: string): Provider {
-  try {
-    const x = new URL(u);
-    if (x.hostname === 'youtu.be' || x.hostname.endsWith('youtube.com')) return 'youtube';
-    if (x.hostname === 'x.com' || x.hostname === 'twitter.com') return 'twitter';
-    if (x.hostname.endsWith('instagram.com')) return 'instagram';
-  } catch {}
-  return 'other';
-}
-
-function ytIdFrom(u: string): string {
-  try {
-    const x = new URL(u);
-    if (x.hostname === 'youtu.be') return x.pathname.slice(1);
-    if (x.hostname.endsWith('youtube.com')) {
-      if (x.pathname.startsWith('/watch')) return x.searchParams.get('v') || '';
-      if (x.pathname.startsWith('/shorts/')) return x.pathname.split('/')[2] || '';
-    }
-  } catch {}
-  return '';
-}
-
-function mkYouTube(id: string) {
-  const canonical = `https://www.youtube.com/watch?v=${id}`;
-  return `<div class="rse-embed embed-video embed-youtube" data-provider="youtube" data-url="${canonical}"></div>`;
-}
-
-function mkTwitter(u: string) {
-  try {
-    const x = new URL(u);
-    const canonical = x.hostname === 'twitter.com' ? u : `https://twitter.com${x.pathname}`;
-    return `<div class="rse-embed embed-social embed-twitter" data-provider="twitter" data-url="${canonical}"></div>`;
-  } catch {
-    return `<div class="rse-embed embed-social embed-twitter" data-provider="twitter" data-url="${u}"></div>`;
-  }
-}
-
-function mkInstagram(u: string) {
-  return `<div class="rse-embed embed-social embed-instagram" data-provider="instagram" data-url="${u}"></div>`;
-}
-
-// Provider専用取得（oEmbed等）。成功したらメタより優先
-async function fetchProviderMeta(url: string): Promise<OGData | null> {
-  try {
-    const u = new URL(url);
-    // YouTube oEmbed
-    if (u.hostname === 'youtu.be' || u.hostname.endsWith('youtube.com')) {
-      let canonical = url;
-      if (u.hostname === 'youtu.be') {
-        const id = u.pathname.slice(1);
-        canonical = `https://www.youtube.com/watch?v=${id}`;
-      }
-      const o = await fetch(`https://www.youtube.com/oembed?format=json&url=${encodeURIComponent(canonical)}`);
-      if (o.ok) {
-        const j: any = await o.json();
-        return { url, title: j.title, image: j.thumbnail_url, siteName: 'YouTube' };
-      }
-    }
-    // X (Twitter) oEmbed（publish.twitter.com）
-    if (u.hostname === 'x.com' || u.hostname === 'twitter.com') {
-      const canonical = `https://twitter.com${u.pathname}`;
-      const o = await fetch(`https://publish.twitter.com/oembed?omit_script=1&hide_thread=1&align=left&url=${encodeURIComponent(canonical)}`);
-      if (o.ok) {
-        const j: any = await o.json();
-        const html: string = j.html || '';
-        const p = html.match(/<p[^>]*>([\s\S]*?)<\/p>/i)?.[1] || '';
-        const text = p
-          .replace(/<br\s*\/>/gi, '\n')
-          .replace(/<[^>]+>/g, '')
-          .replace(/&amp;/g, '&')
-          .replace(/&lt;/g, '<')
-          .replace(/&gt;/g, '>')
-          .replace(/&quot;/g, '"')
-          .replace(/&#39;/g, "'")
-          .trim();
-        return { url, title: text || j.author_name || 'Tweet', siteName: 'X (Twitter)' };
-      }
-      return null;
-    }
-  } catch {}
-  return null;
-}
-
-async function fetchOG(url: string): Promise<OGData | null> {
-  if (shouldDisableOgFetch()) {
-    return { url };
-  }
-  try {
-    // まずはプロバイダ専用の取得
-    const provider = await fetchProviderMeta(url);
-    if (provider) return { ...provider, fetchedAt: Date.now() };
-
-    const res = await fetch(url, {
-      headers: {
-        'User-Agent':
-          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
-        'Accept-Language': 'ja-JP,ja;q=0.9,en-US;q=0.8,en;q=0.7',
-      },
-      redirect: 'follow',
-    });
-    if (!res.ok) return providerFallback(url) || { url };
-    const text = await res.text();
-    const head = text.slice(0, 500_000);
-    const data = extractMeta(head, url);
-    // Amazon: 本文の productTitle を補助的に利用
-    try {
-      const u = new URL(url);
-      if (/amazon\.(co\.jp|com)$|amzn\.to$/.test(u.hostname)) {
-        if (!data.title) {
-          const m = text.match(/<span[^>]*id=['"]productTitle['"][^>]*>([\s\S]*?)<\/span>/i);
-          const t = m ? m[1].replace(/\s+/g, ' ').trim() : '';
-          if (t) data.title = t;
-        }
-        data.siteName = data.siteName || 'Amazon';
-      }
-    } catch {}
-    data.fetchedAt = Date.now();
-    const hasAny = !!(data.title || data.image || data.description || data.siteName);
-    return hasAny ? data : providerFallback(url) || data;
-  } catch {
-    // Provider専用フォールバック（ネットワーク不可/OGなし）
-    return providerFallback(url);
-  }
-}
-
 function isAllowed(url: string, allow: string[]) {
   try {
     const u = new URL(url);
@@ -267,37 +21,6 @@ function isAllowed(url: string, allow: string[]) {
   } catch {
     return false;
   }
-}
-
-function makeCardHTML(u: string, og: OGData | null) {
-  const host = (() => {
-    try {
-      return new URL(u).hostname;
-    } catch {
-      return u;
-    }
-  })();
-  const title = og?.title || u;
-  const desc = og?.description || '';
-  const img = og?.image || '';
-  const site = og?.siteName || host;
-  const esc = (s?: string) => (s ? escapeHtml(s) : '');
-  const noimg = !img;
-  const imgTag = img
-    ? `<div class="og-card__thumb"><img src="${esc(img)}" alt="" loading="lazy" referrerpolicy="no-referrer" /></div>`
-    : '';
-  const urlText = prettyUrl(u);
-  return (
-    `<a class="og-card card ${noimg ? 'og-card--noimg' : ''}" href="${esc(u)}" target="_blank" rel="noopener noreferrer">
-      ${imgTag}
-      <div class="og-card__body">
-        <div class="og-card__site">${esc(site)}</div>
-        <div class="og-card__title">${esc(title)}</div>
-        ${desc ? `<div class=\"og-card__desc\">${esc(desc)}</div>` : ''}
-        <div class="og-card__url">${esc(urlText)}</div>
-      </div>
-    </a>`
-  );
 }
 
 // naive walk over mdast
@@ -322,6 +45,7 @@ export default function remarkLinkCard(options?: Options) {
   const ttlMs = Number.isFinite(options?.ttlMs as number)
     ? (options?.ttlMs as number)
     : getOgCacheTtlMs();
+
   return async function transformer(tree: any) {
     const targets: { parent: any; index: number; url: string }[] = [];
     walk(tree, (node, parent, index) => {
@@ -343,55 +67,36 @@ export default function remarkLinkCard(options?: Options) {
 
     const cache = await readCache(cacheFile);
     let cacheChanged = false;
-    const updateCache = (url: string, data: OGData) => {
-      const prev = cache[url];
-      const same = prev && JSON.stringify(prev) === JSON.stringify(data);
-      if (!same) {
-        cache[url] = data;
-        cacheChanged = true;
-      }
-    };
     const outNodes: { html: string; parent: any; index: number; url: string }[] = [];
 
     for (const t of targets) {
       const provider = providerOf(t.url);
-      if (provider === 'youtube') {
-        const id = ytIdFrom(t.url);
-        if (id) {
-          outNodes.push({ html: mkYouTube(id), parent: t.parent, index: t.index, url: t.url });
-          continue;
-        }
-      }
-      if (provider === 'twitter') {
-        outNodes.push({ html: mkTwitter(t.url), parent: t.parent, index: t.index, url: t.url });
-        continue;
-      }
-      if (provider === 'instagram') {
-        outNodes.push({ html: mkInstagram(t.url), parent: t.parent, index: t.index, url: t.url });
+      const embed = embedHtmlFor(provider, t.url);
+      if (embed) {
+        outNodes.push({ html: embed, parent: t.parent, index: t.index, url: t.url });
         continue;
       }
 
       const cached = cache[t.url];
       let og: OGData | null = null;
-      const fresh = cached && cached.fetchedAt && Date.now() - (cached.fetchedAt || 0) < ttlMs;
-      const cachedHasPreview = !!(
-        cached && (cached.title || cached.image || cached.description || cached.siteName)
-      );
+      const fresh = isFresh(cached, ttlMs);
+      const cachedHasPreview = hasPreview(cached);
       if (cached && fresh && cachedHasPreview) {
         og = cached;
       } else {
         const fetched = await fetchOG(t.url);
         if (fetched) {
-          updateCache(t.url, fetched);
           og = fetched;
+          const changed = upsertCache(cache, t.url, fetched);
+          cacheChanged = cacheChanged || changed;
         } else if (cached) {
           // フェッチ失敗時は古いキャッシュで代替
           og = cached;
         }
       }
       // OGP/Twitter Cardが検出できた場合のみカード化（少なくとも title or image）
-      const hasPreview = !!(og && (og.title || og.image || og.description || og.siteName));
-      if (hasPreview) {
+      const hasCard = hasPreview(og);
+      if (hasCard) {
         outNodes.push({ html: makeCardHTML(t.url, og), parent: t.parent, index: t.index, url: t.url });
       }
     }

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,17 +1,22 @@
 export type UiLocale = 'ja' | 'en';
 
-export function formatDate(dateLike: string, locale: UiLocale = 'ja') {
-  // 安定化: 常にUTC基準で日付部分のみを使用
-  let d = new Date(dateLike);
-  if (isNaN(d.getTime())) {
-    // フォールバック: 先頭10文字
-    const s = (dateLike || '').toString().slice(0, 10);
-    return s;
-  }
-  const y = d.getUTCFullYear();
-  const m = (d.getUTCMonth() + 1).toString().padStart(2, '0');
-  const day = d.getUTCDate().toString().padStart(2, '0');
-  // 表記はロケールで簡易分岐（必要なら拡張）
-  return locale === 'ja' ? `${y}/${m}/${day}` : `${y}-${m}-${day}`;
+function normalizeDate(input: string | Date | undefined | null): Date | null {
+  if (!input) return null;
+  const d = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(d.getTime())) return null;
+  return d;
 }
 
+function formatIsoParts(date: Date) {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const d = String(date.getUTCDate()).padStart(2, '0');
+  return { y, m, d };
+}
+
+export function formatDate(dateLike: string, locale: UiLocale = 'ja') {
+  const date = normalizeDate(dateLike);
+  if (!date) return (dateLike || '').toString().slice(0, 10);
+  const { y, m, d } = formatIsoParts(date);
+  return locale === 'ja' ? `${y}/${m}/${d}` : `${y}-${m}-${d}`;
+}

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -8,3 +8,8 @@ export const dictionaries: Record<Locale, typeof ja> = {
   en,
 };
 
+export const SUPPORTED_LOCALES: Locale[] = ['ja', 'en'];
+
+export function resolveLocale(raw: string): Locale {
+  return raw === 'en' ? 'en' : 'ja';
+}

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import { buildPageMetadata, defaultLanguageAlternates } from '@/lib/seo';
+import type { Locale } from '@/lib/i18n';
+import { resolveLocale, SUPPORTED_LOCALES } from '@/lib/i18n';
+
+type CopyBase = {
+  metadataTitle: string;
+  metadataDescription: string;
+  path: string;
+};
+
+export function localizedStaticParams() {
+  return SUPPORTED_LOCALES.map((locale) => ({ locale }));
+}
+
+export async function buildLocalizedMetadata(
+  params: Promise<{ locale: string }>,
+  copyMap: Record<Locale, CopyBase>,
+  extra?: Partial<Pick<Parameters<typeof buildPageMetadata>[0], 'images' | 'keywords' | 'type' | 'languageAlternates'>>,
+): Promise<Metadata> {
+  const locale = resolveLocale((await params).locale);
+  const copy = copyMap[locale];
+  return buildPageMetadata({
+    title: copy.metadataTitle,
+    description: copy.metadataDescription,
+    locale,
+    path: copy.path,
+    languageAlternates: extra?.languageAlternates ?? defaultLanguageAlternates,
+    images: extra?.images,
+    keywords: extra?.keywords,
+    type: extra?.type,
+  });
+}

--- a/src/lib/routing.ts
+++ b/src/lib/routing.ts
@@ -1,0 +1,30 @@
+import type { Locale } from '@/lib/i18n';
+
+const LOCALE_PREFIX = /^\/(ja|en)(\/|$)/;
+
+export function extractLocaleFromPath(pathname: string): Locale | null {
+  const m = pathname.match(LOCALE_PREFIX);
+  if (!m) return null;
+  return m[1] === 'en' ? 'en' : 'ja';
+}
+
+export function stripLocalePrefix(pathname: string): string {
+  return pathname.replace(LOCALE_PREFIX, '/');
+}
+
+export function localizedPath(path: string, locale: Locale): string {
+  const normalized = path.endsWith('/') ? path : `${path}/`;
+  if (normalized === '/' || normalized === '/ja/' || normalized === '/en/') {
+    return locale === 'ja' ? '/ja/' : '/en/';
+  }
+  const clean = normalized.startsWith('/') ? normalized : `/${normalized}`;
+  return `/${locale}${clean}`.replace(/\/+/g, '/');
+}
+
+export function isTranslatablePath(pathname: string): boolean {
+  if (!pathname) return false;
+  const bare = stripLocalePrefix(pathname);
+  return ['/', '/links/', '/publications/', '/blogs/'].includes(
+    bare.endsWith('/') ? bare : `${bare}/`,
+  );
+}

--- a/src/lib/seo/metaConfig.ts
+++ b/src/lib/seo/metaConfig.ts
@@ -1,0 +1,67 @@
+import type { Locale } from '@/lib/i18n';
+import { siteConfig } from '@/lib/seo';
+
+export type PageKey = 'home' | 'blogs' | 'links' | 'publications';
+
+export type PageMeta = {
+  metadataTitle: string;
+  metadataDescription: string;
+  path: string;
+};
+
+export const pageMeta: Record<PageKey, Record<Locale, PageMeta>> = {
+  home: {
+    ja: {
+      metadataTitle: siteConfig.defaultTitle.ja,
+      metadataDescription: siteConfig.description.ja,
+      path: '/',
+    },
+    en: {
+      metadataTitle: siteConfig.defaultTitle.en,
+      metadataDescription: siteConfig.description.en,
+      path: '/en/',
+    },
+  },
+  blogs: {
+    ja: {
+      metadataTitle: 'ブログ記事一覧',
+      metadataDescription: '岡田 龍樹による自然言語処理や機械学習に関するブログ記事の一覧です。',
+      path: '/ja/blogs/',
+    },
+    en: {
+      metadataTitle: 'Blog Posts',
+      metadataDescription:
+        'Browse blog posts by Tatsuki Okada about natural language processing, machine learning, and development.',
+      path: '/en/blogs/',
+    },
+  },
+  links: {
+    ja: {
+      metadataTitle: 'リンク集',
+      metadataDescription: 'SNSアカウントやプロジェクトなど、岡田 龍樹に関連する外部リンクをまとめています。',
+      path: '/ja/links/',
+    },
+    en: {
+      metadataTitle: 'Links',
+      metadataDescription: "A curated list of Tatsuki Okada social accounts, projects, and recommended resources.",
+      path: '/en/links/',
+    },
+  },
+  publications: {
+    ja: {
+      metadataTitle: '公開物',
+      metadataDescription: '研究論文や記事、登壇資料など、岡田龍樹が携わった公開物の一覧です。',
+      path: '/ja/publications/',
+    },
+    en: {
+      metadataTitle: 'Publications',
+      metadataDescription:
+        'Academic publications, articles, and talks by Tatsuki Okada in the field of NLP and machine learning.',
+      path: '/en/publications/',
+    },
+  },
+};
+
+export function getPageMeta(page: PageKey, locale: Locale): PageMeta {
+  return pageMeta[page][locale];
+}

--- a/src/lib/ui/inlineMarkdown.tsx
+++ b/src/lib/ui/inlineMarkdown.tsx
@@ -1,0 +1,28 @@
+import React, { type ReactNode } from 'react';
+
+const linkPattern = /\[([^\]]+)]\(([^)]+)\)/g;
+
+export function renderInlineLinks(text: string): ReactNode {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+  let match: RegExpExecArray | null;
+  let key = 0;
+  while ((match = linkPattern.exec(text))) {
+    const [full, label, url] = match;
+    if (match.index > lastIndex) nodes.push(text.slice(lastIndex, match.index));
+    nodes.push(
+      <a
+        key={`inline-link-${key++}`}
+        href={url}
+        target="_blank"
+        rel="noreferrer"
+        className="underline underline-offset-2 hover:no-underline"
+      >
+        {label}
+      </a>,
+    );
+    lastIndex = match.index + full.length;
+  }
+  if (lastIndex < text.length) nodes.push(text.slice(lastIndex));
+  return nodes.length ? nodes : text;
+}

--- a/src/lib/url.ts
+++ b/src/lib/url.ts
@@ -3,6 +3,11 @@ import { getAssetVersion, getBasePath } from '@/lib/config/env';
 export const BASE_PATH = getBasePath();
 export const ASSET_VERSION = getAssetVersion();
 
+export function assetPath(src: string): string | undefined {
+  const withBase = withBasePath(src.startsWith('/') ? src : `/${src}`);
+  return withVersion(withBase);
+}
+
 export function withBasePath(src?: string | null): string | undefined {
   if (!src) return undefined;
   if (/^(https?:)?\/\//i.test(src) || src.startsWith('data:')) return src;

--- a/src/stories/fixtures/links.ts
+++ b/src/stories/fixtures/links.ts
@@ -1,0 +1,46 @@
+import type { LinkItem } from '@/lib/data/links';
+
+export const sampleLinks: LinkItem[] = [
+  {
+    title: 'GitHub',
+    url: 'https://github.com/iamtatsuki05',
+    desc: 'ソースコードとプロジェクト',
+    iconUrl: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/github/github-original.svg',
+    category: 'Social',
+  },
+  {
+    title: 'X (Twitter)',
+    url: 'https://x.com/iam_tatsuki05',
+    desc: '日々の発信',
+    iconUrl: 'https://cdn.jsdelivr.net/gh/devicons/devicon@latest/icons/twitter/twitter-original.svg',
+    category: 'Social',
+  },
+  {
+    title: 'Instagram',
+    url: 'https://www.instagram.com/iam_tatsuki05',
+    desc: '写真・日常',
+    iconUrl: 'https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/instagram.svg',
+    category: 'Social',
+  },
+  {
+    title: 'LinkedIn',
+    url: 'https://www.linkedin.com/in/iamtatsuki05',
+    desc: '職務経歴・プロフィール',
+    iconUrl: 'https://raw.githubusercontent.com/rahuldkjain/github-profile-readme-generator/master/src/images/icons/Social/linked-in-alt.svg',
+    category: 'Social',
+  },
+  {
+    title: 'Huggingface',
+    url: 'https://huggingface.co/iamtatsuki05',
+    desc: 'モデル・データセット・アプリ',
+    iconUrl: 'https://huggingface.co/front/assets/huggingface_logo-noborder.svg',
+    category: 'Social',
+  },
+  {
+    title: 'Blog',
+    url: 'https://iamtatsuki05.github.io/blogs/',
+    desc: 'ブログ一覧',
+    iconUrl: 'https://cdn.simpleicons.org/rss',
+    category: 'Projects',
+  },
+];

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -1,0 +1,18 @@
+@layer components {
+  /* Common UI atoms */
+  .ui-card {
+    @apply border border-gray-200 dark:border-gray-800 rounded-lg bg-white dark:bg-gray-900 shadow-xs transition hover:shadow-md hover:-translate-y-0.5;
+  }
+
+  .card {
+    @apply border border-gray-200 dark:border-gray-800 rounded-lg bg-white dark:bg-gray-900 shadow-xs transition hover:shadow-md hover:-translate-y-0.5;
+  }
+
+  .ui-tag {
+    @apply inline-block px-2 py-0.5 rounded-sm bg-gray-100 dark:bg-gray-800 text-xs;
+  }
+
+  .tag {
+    @apply inline-block px-2 py-0.5 rounded-sm bg-gray-100 dark:bg-gray-800 text-xs;
+  }
+}

--- a/tests/components/navlinks.test.tsx
+++ b/tests/components/navlinks.test.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { NavLinks } from '@/components/site/NavLinks';
-import { NAV_ITEMS } from '@/components/site/navItems';
+import { resolveNavItems } from '@/components/site/navItems';
 
 describe('NavLinks', () => {
   const activePath = '/blogs/';
   const localePrefix = '';
+  const items = resolveNavItems('ja');
 
   it('renders navigation items and marks active link', () => {
-    render(<NavLinks items={NAV_ITEMS} activePath={activePath} localePrefix={localePrefix} />);
+    render(<NavLinks items={items} activePath={activePath} localePrefix={localePrefix} />);
 
     const blogLink = screen.getByText('📝 Blog');
     expect(blogLink).toBeVisible();
@@ -19,7 +20,7 @@ describe('NavLinks', () => {
     const handler = vi.fn();
     render(
       <NavLinks
-        items={NAV_ITEMS}
+        items={items}
         activePath={activePath}
         localePrefix={localePrefix}
         onNavigate={handler}
@@ -33,7 +34,7 @@ describe('NavLinks', () => {
   it('renders vertical layout when orientation is vertical', () => {
     render(
       <NavLinks
-        items={NAV_ITEMS}
+        items={items}
         activePath="/"
         localePrefix=""
         orientation="vertical"
@@ -44,4 +45,3 @@ describe('NavLinks', () => {
     expect(nav.className).toContain('flex-col');
   });
 });
-


### PR DESCRIPTION
# WHY

# WHAT
- Added shared filter text dictionaries and refactored Blogs/Publications filter UI to use them.
- Introduced reusable FilterBar component and moved filter controls (search/year/tags/types) to it.
- Split UI styles into component-layer classes (ui-card, ui-tag) and ensured Tailwind applies them safely.
- Added Storybook coverage for FilterBar/filters and consolidated links fixtures.
- Compact toggle for Publications “Types” filter and fixed filter label usage.
- E2E and unit tests updated; bun run e2e:run and bun run vitest:run now pass.