### PR TITLE
fix: keep mobile header fixed on scroll

### DIFF
--- a/e2e/site-pages.spec.ts
+++ b/e2e/site-pages.spec.ts
@@ -12,6 +12,35 @@ const viewports = [
   },
 ] as const;
 
+test.describe('Site header (mobile)', () => {
+  test.use({ viewport: { width: 375, height: 667 } });
+
+  test('stays fixed while scrolling down the page', async ({ page }) => {
+    await page.goto(localizedPath('ja', '/blogs/'));
+
+    const header = page.locator('header').first();
+    await expect(header).toHaveCSS('position', 'fixed');
+
+    const before = await header.boundingBox();
+    expect(before).not.toBeNull();
+
+    await page.evaluate(() => window.scrollTo({ top: document.body.scrollHeight, behavior: 'instant' }));
+
+    await expect.poll(async () => Math.round((await header.boundingBox())?.y ?? -1)).toBe(0);
+    await expect(header).toBeVisible();
+  });
+});
+
+test.describe('Site header (desktop)', () => {
+  test.use({ viewport: { width: 1280, height: 800 } });
+
+  test('keeps the existing sticky header behavior', async ({ page }) => {
+    await page.goto(localizedPath('ja', '/blogs/'));
+
+    await expect(page.locator('header').first()).toHaveCSS('position', 'sticky');
+  });
+});
+
 for (const { label, use } of viewports) {
   test.describe(`Blog index page (${label})`, () => {
     test.use(use);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -104,7 +104,7 @@ export default function RootLayout({
         <NuqsAdapter>
           <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
             <Header />
-            <main className="container mx-auto max-w-screen-2xl px-4 py-8 flex-1">
+            <main className="container mx-auto max-w-screen-2xl px-4 pt-28 pb-8 sm:py-8 flex-1">
               {children}
             </main>
             <Footer />

--- a/src/components/site/Header.tsx
+++ b/src/components/site/Header.tsx
@@ -37,7 +37,7 @@ export function Header() {
   }, []);
 
   return (
-    <header className="sticky top-0 z-40 border-b border-purple-100/70 bg-gradient-to-r from-[#f8f5ff]/85 via-[#fff6e6]/90 to-[#f4eeff]/85 backdrop-blur-sm shadow-sm dark:border-purple-500/40 dark:from-[#120d1f]/90 dark:via-[#0f0a17]/90 dark:to-[#140f24]/88">
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-purple-100/70 bg-gradient-to-r from-[#f8f5ff]/85 via-[#fff6e6]/90 to-[#f4eeff]/85 backdrop-blur-sm shadow-sm sm:sticky sm:z-40 dark:border-purple-500/40 dark:from-[#120d1f]/90 dark:via-[#0f0a17]/90 dark:to-[#140f24]/88">
       <div className="container mx-auto flex max-w-screen-2xl items-center justify-between gap-3 px-4 py-4">
         <Link
           href={localizedPath('/', locale)}


### PR DESCRIPTION
# WHY
Fix mobile header disappearing while scrolling

# WHAT
- keep the site header fixed on mobile scroll
- preserve the existing sticky header behavior on desktop
- add e2e coverage for mobile fixed header and desktop sticky header
