### PR TITLE
feat: add voice search input with the Web Speech API

### DIFF
--- a/src/components/filters/FilterBar.tsx
+++ b/src/components/filters/FilterBar.tsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import { useEffect, useRef } from 'react';
+import type React from 'react';
+import { useSpeechRecognition } from '@/hooks/useSpeechRecognition';
 
 export type FilterBarActiveFilter = {
   key: string;
@@ -23,6 +25,10 @@ type Props = {
   activeFilters?: FilterBarActiveFilter[];
   sortControls?: React.ReactNode;
   stickyMetaOnMobile?: boolean;
+  /** 音声入力の認識言語 (例: 'ja-JP')。未指定ならマイクボタンを表示しない。 */
+  voiceLang?: string;
+  voiceStartLabel?: string;
+  voiceStopLabel?: string;
 };
 
 export function FilterBar({
@@ -41,10 +47,25 @@ export function FilterBar({
   activeFilters = [],
   sortControls,
   stickyMetaOnMobile = false,
+  voiceLang,
+  voiceStartLabel = 'Search by voice',
+  voiceStopLabel = 'Stop voice input',
 }: Props) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const showClear = Boolean(hasActiveFilters) || Boolean(query);
   const showMeta = Boolean(resultLabel) || activeFilters.length > 0 || Boolean(sortControls);
+
+  const {
+    supported: voiceSupported,
+    listening: voiceListening,
+    toggle: toggleVoice,
+  } = useSpeechRecognition({
+    lang: voiceLang ?? 'en-US',
+    onResult: (transcript) => {
+      onQueryChange(transcript);
+    },
+  });
+  const showVoiceButton = Boolean(voiceLang) && voiceSupported;
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -70,7 +91,7 @@ export function FilterBar({
   return (
     <div data-filter-bar-root="true" className={`filter-bar space-y-3 ${className || ''}`}>
       <div className="filter-bar__controls flex flex-wrap items-center gap-3">
-        <div className="filter-bar__search">
+        <div className={`filter-bar__search ${showVoiceButton ? 'filter-bar__search--voice' : ''}`}>
           <input
             ref={inputRef}
             aria-label={placeholder}
@@ -96,6 +117,36 @@ export function FilterBar({
             <span className="filter-bar__search-status" role="status" aria-live="polite">
               {searchLoadingLabel}
             </span>
+          ) : null}
+          {showVoiceButton ? (
+            <button
+              type="button"
+              onClick={() => {
+                onSearchIntent?.();
+                toggleVoice();
+              }}
+              aria-label={voiceListening ? voiceStopLabel : voiceStartLabel}
+              aria-pressed={voiceListening}
+              data-state={voiceListening ? 'listening' : 'idle'}
+              data-testid="filter-voice-button"
+              className="filter-bar__voice focus-ring"
+            >
+              <svg
+                viewBox="0 0 24 24"
+                width="16"
+                height="16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+              >
+                <path d="M12 2a3 3 0 0 1 3 3v6a3 3 0 0 1-6 0V5a3 3 0 0 1 3-3Z" />
+                <path d="M19 10v1a7 7 0 0 1-14 0v-1" />
+                <line x1="12" y1="18" x2="12" y2="22" />
+              </svg>
+            </button>
           ) : null}
         </div>
 

--- a/src/components/filters/FilterBar.tsx
+++ b/src/components/filters/FilterBar.tsx
@@ -29,6 +29,7 @@ type Props = {
   voiceLang?: string;
   voiceStartLabel?: string;
   voiceStopLabel?: string;
+  voiceListeningLabel?: string;
   voicePermissionMessage?: string;
   voiceNoSpeechMessage?: string;
   voiceUnavailableMessage?: string;
@@ -53,6 +54,7 @@ export function FilterBar({
   voiceLang,
   voiceStartLabel = 'Search by voice',
   voiceStopLabel = 'Stop voice input',
+  voiceListeningLabel = 'Listening...',
   voicePermissionMessage = 'Microphone access is blocked',
   voiceNoSpeechMessage = 'No speech detected',
   voiceUnavailableMessage = 'Voice input is unavailable',
@@ -105,7 +107,11 @@ export function FilterBar({
   return (
     <div data-filter-bar-root="true" className={`filter-bar space-y-3 ${className || ''}`}>
       <div className="filter-bar__controls flex flex-wrap items-center gap-3">
-        <div className={`filter-bar__search ${showVoiceButton ? 'filter-bar__search--voice' : ''}`}>
+        <div
+          className={`filter-bar__search ${showVoiceButton ? 'filter-bar__search--voice' : ''} ${
+            voiceListening ? 'filter-bar__search--listening' : ''
+          }`}
+        >
           <input
             ref={inputRef}
             aria-label={placeholder}
@@ -132,7 +138,17 @@ export function FilterBar({
               {searchLoadingLabel}
             </span>
           ) : null}
-          {!isSearchLoading && voiceErrorMessage ? (
+          {voiceListening ? (
+            <span
+              className="filter-bar__search-status filter-bar__search-status--listening"
+              role="status"
+              aria-live="polite"
+              data-testid="filter-voice-listening"
+            >
+              {voiceListeningLabel}
+            </span>
+          ) : null}
+          {!isSearchLoading && !voiceListening && voiceErrorMessage ? (
             <span
               className="filter-bar__search-status filter-bar__search-status--error"
               role="status"

--- a/src/components/filters/FilterBar.tsx
+++ b/src/components/filters/FilterBar.tsx
@@ -29,6 +29,9 @@ type Props = {
   voiceLang?: string;
   voiceStartLabel?: string;
   voiceStopLabel?: string;
+  voicePermissionMessage?: string;
+  voiceNoSpeechMessage?: string;
+  voiceUnavailableMessage?: string;
 };
 
 export function FilterBar({
@@ -50,6 +53,9 @@ export function FilterBar({
   voiceLang,
   voiceStartLabel = 'Search by voice',
   voiceStopLabel = 'Stop voice input',
+  voicePermissionMessage = 'Microphone access is blocked',
+  voiceNoSpeechMessage = 'No speech detected',
+  voiceUnavailableMessage = 'Voice input is unavailable',
 }: Props) {
   const inputRef = useRef<HTMLInputElement | null>(null);
   const showClear = Boolean(hasActiveFilters) || Boolean(query);
@@ -58,6 +64,7 @@ export function FilterBar({
   const {
     supported: voiceSupported,
     listening: voiceListening,
+    error: voiceError,
     toggle: toggleVoice,
   } = useSpeechRecognition({
     lang: voiceLang ?? 'en-US',
@@ -66,6 +73,13 @@ export function FilterBar({
     },
   });
   const showVoiceButton = Boolean(voiceLang) && voiceSupported;
+  const voiceErrorMessage = voiceError
+    ? {
+        permission: voicePermissionMessage,
+        'no-speech': voiceNoSpeechMessage,
+        unavailable: voiceUnavailableMessage,
+      }[voiceError]
+    : null;
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
@@ -116,6 +130,16 @@ export function FilterBar({
           {isSearchLoading ? (
             <span className="filter-bar__search-status" role="status" aria-live="polite">
               {searchLoadingLabel}
+            </span>
+          ) : null}
+          {!isSearchLoading && voiceErrorMessage ? (
+            <span
+              className="filter-bar__search-status filter-bar__search-status--error"
+              role="status"
+              aria-live="polite"
+              data-testid="filter-voice-error"
+            >
+              {voiceErrorMessage}
             </span>
           ) : null}
           {showVoiceButton ? (

--- a/src/components/filters/filterTexts.ts
+++ b/src/components/filters/filterTexts.ts
@@ -14,7 +14,9 @@ export type FilterTextKey =
   | 'searchKeyword'
   | 'sort'
   | 'sortRelevant'
-  | 'sortNewest';
+  | 'sortNewest'
+  | 'voiceStart'
+  | 'voiceStop';
 
 export type FilterTextDict = Record<FilterTextKey, string>;
 
@@ -33,6 +35,8 @@ export const filterTextJa: FilterTextDict = {
   sort: '並び替え',
   sortRelevant: '関連順',
   sortNewest: '新しい順',
+  voiceStart: '音声で検索',
+  voiceStop: '音声入力を停止',
 };
 
 export const filterTextEn: FilterTextDict = {
@@ -50,6 +54,8 @@ export const filterTextEn: FilterTextDict = {
   sort: 'Sort',
   sortRelevant: 'Relevant',
   sortNewest: 'Newest',
+  voiceStart: 'Search by voice',
+  voiceStop: 'Stop voice input',
 };
 
 export const filterTextZh: FilterTextDict = {
@@ -67,6 +73,8 @@ export const filterTextZh: FilterTextDict = {
   sort: '排序',
   sortRelevant: '相关度',
   sortNewest: '最新',
+  voiceStart: '语音搜索',
+  voiceStop: '停止语音输入',
 };
 
 export const filterTextFr: FilterTextDict = {
@@ -84,6 +92,8 @@ export const filterTextFr: FilterTextDict = {
   sort: 'Tri',
   sortRelevant: 'Pertinence',
   sortNewest: 'Plus récent',
+  voiceStart: 'Recherche vocale',
+  voiceStop: 'Arrêter la saisie vocale',
 };
 
 export function resolveFilterText(locale: Locale): FilterTextDict {

--- a/src/components/filters/filterTexts.ts
+++ b/src/components/filters/filterTexts.ts
@@ -16,7 +16,10 @@ export type FilterTextKey =
   | 'sortRelevant'
   | 'sortNewest'
   | 'voiceStart'
-  | 'voiceStop';
+  | 'voiceStop'
+  | 'voicePermission'
+  | 'voiceNoSpeech'
+  | 'voiceUnavailable';
 
 export type FilterTextDict = Record<FilterTextKey, string>;
 
@@ -37,6 +40,9 @@ export const filterTextJa: FilterTextDict = {
   sortNewest: '新しい順',
   voiceStart: '音声で検索',
   voiceStop: '音声入力を停止',
+  voicePermission: 'マイクの使用が許可されていません',
+  voiceNoSpeech: '音声を検出できませんでした',
+  voiceUnavailable: '音声入力を利用できません',
 };
 
 export const filterTextEn: FilterTextDict = {
@@ -56,6 +62,9 @@ export const filterTextEn: FilterTextDict = {
   sortNewest: 'Newest',
   voiceStart: 'Search by voice',
   voiceStop: 'Stop voice input',
+  voicePermission: 'Microphone access is blocked',
+  voiceNoSpeech: 'No speech detected',
+  voiceUnavailable: 'Voice input is unavailable',
 };
 
 export const filterTextZh: FilterTextDict = {
@@ -75,6 +84,9 @@ export const filterTextZh: FilterTextDict = {
   sortNewest: '最新',
   voiceStart: '语音搜索',
   voiceStop: '停止语音输入',
+  voicePermission: '麦克风权限未开启',
+  voiceNoSpeech: '未检测到语音',
+  voiceUnavailable: '语音输入不可用',
 };
 
 export const filterTextFr: FilterTextDict = {
@@ -94,6 +106,9 @@ export const filterTextFr: FilterTextDict = {
   sortNewest: 'Plus récent',
   voiceStart: 'Recherche vocale',
   voiceStop: 'Arrêter la saisie vocale',
+  voicePermission: 'L’accès au micro est bloqué',
+  voiceNoSpeech: 'Aucune voix détectée',
+  voiceUnavailable: 'La saisie vocale est indisponible',
 };
 
 export function resolveFilterText(locale: Locale): FilterTextDict {

--- a/src/components/filters/filterTexts.ts
+++ b/src/components/filters/filterTexts.ts
@@ -17,6 +17,7 @@ export type FilterTextKey =
   | 'sortNewest'
   | 'voiceStart'
   | 'voiceStop'
+  | 'voiceListening'
   | 'voicePermission'
   | 'voiceNoSpeech'
   | 'voiceUnavailable';
@@ -40,6 +41,7 @@ export const filterTextJa: FilterTextDict = {
   sortNewest: '新しい順',
   voiceStart: '音声で検索',
   voiceStop: '音声入力を停止',
+  voiceListening: '聞き取り中...',
   voicePermission: 'マイクの使用が許可されていません',
   voiceNoSpeech: '音声を検出できませんでした',
   voiceUnavailable: '音声入力を利用できません',
@@ -62,6 +64,7 @@ export const filterTextEn: FilterTextDict = {
   sortNewest: 'Newest',
   voiceStart: 'Search by voice',
   voiceStop: 'Stop voice input',
+  voiceListening: 'Listening...',
   voicePermission: 'Microphone access is blocked',
   voiceNoSpeech: 'No speech detected',
   voiceUnavailable: 'Voice input is unavailable',
@@ -84,6 +87,7 @@ export const filterTextZh: FilterTextDict = {
   sortNewest: '最新',
   voiceStart: '语音搜索',
   voiceStop: '停止语音输入',
+  voiceListening: '正在聆听...',
   voicePermission: '麦克风权限未开启',
   voiceNoSpeech: '未检测到语音',
   voiceUnavailable: '语音输入不可用',
@@ -106,6 +110,7 @@ export const filterTextFr: FilterTextDict = {
   sortNewest: 'Plus récent',
   voiceStart: 'Recherche vocale',
   voiceStop: 'Arrêter la saisie vocale',
+  voiceListening: 'À l’écoute...',
   voicePermission: 'L’accès au micro est bloqué',
   voiceNoSpeech: 'Aucune voix détectée',
   voiceUnavailable: 'La saisie vocale est indisponible',

--- a/src/components/pages/BlogsClient.tsx
+++ b/src/components/pages/BlogsClient.tsx
@@ -159,6 +159,9 @@ export function BlogsClient({
         voiceLang={localeToRouteLocale(locale)}
         voiceStartLabel={t.voiceStart}
         voiceStopLabel={t.voiceStop}
+        voicePermissionMessage={t.voicePermission}
+        voiceNoSpeechMessage={t.voiceNoSpeech}
+        voiceUnavailableMessage={t.voiceUnavailable}
       >
         <YearSelect
           years={allYears}

--- a/src/components/pages/BlogsClient.tsx
+++ b/src/components/pages/BlogsClient.tsx
@@ -159,6 +159,7 @@ export function BlogsClient({
         voiceLang={localeToRouteLocale(locale)}
         voiceStartLabel={t.voiceStart}
         voiceStopLabel={t.voiceStop}
+        voiceListeningLabel={t.voiceListening}
         voicePermissionMessage={t.voicePermission}
         voiceNoSpeechMessage={t.voiceNoSpeech}
         voiceUnavailableMessage={t.voiceUnavailable}

--- a/src/components/pages/BlogsClient.tsx
+++ b/src/components/pages/BlogsClient.tsx
@@ -24,7 +24,7 @@ import { SectionHeader } from '@/components/home/sections/SectionHeader';
 import { SearchHighlight } from '@/components/search/SearchHighlight';
 import { useInitialReveal } from '@/hooks/useInitialReveal';
 import { buildBlogPostHref } from '@/lib/blog/navigation';
-import type { Locale } from '@/lib/i18n';
+import { type Locale, localeToRouteLocale } from '@/lib/i18n';
 
 const INITIAL_VISIBLE_COUNT = 10;
 const LOAD_MORE_INCREMENT = 10;
@@ -156,6 +156,9 @@ export function BlogsClient({
         activeFilters={activeFilters}
         sortControls={<SearchSortControls visible={Boolean(q)} sort={sort} onSortChange={setSort} texts={t} />}
         stickyMetaOnMobile
+        voiceLang={localeToRouteLocale(locale)}
+        voiceStartLabel={t.voiceStart}
+        voiceStopLabel={t.voiceStop}
       >
         <YearSelect
           years={allYears}

--- a/src/components/pages/PublicationsClient.tsx
+++ b/src/components/pages/PublicationsClient.tsx
@@ -278,6 +278,9 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
         voiceLang={localeToRouteLocale(locale)}
         voiceStartLabel={t.voiceStart}
         voiceStopLabel={t.voiceStop}
+        voicePermissionMessage={t.voicePermission}
+        voiceNoSpeechMessage={t.voiceNoSpeech}
+        voiceUnavailableMessage={t.voiceUnavailable}
       >
         <YearSelect
           years={years}

--- a/src/components/pages/PublicationsClient.tsx
+++ b/src/components/pages/PublicationsClient.tsx
@@ -278,6 +278,7 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
         voiceLang={localeToRouteLocale(locale)}
         voiceStartLabel={t.voiceStart}
         voiceStopLabel={t.voiceStop}
+        voiceListeningLabel={t.voiceListening}
         voicePermissionMessage={t.voicePermission}
         voiceNoSpeechMessage={t.voiceNoSpeech}
         voiceUnavailableMessage={t.voiceUnavailable}

--- a/src/components/pages/PublicationsClient.tsx
+++ b/src/components/pages/PublicationsClient.tsx
@@ -25,7 +25,7 @@ import { SectionShell } from '@/components/home/SectionShell';
 import { SectionHeader } from '@/components/home/sections/SectionHeader';
 import { SearchHighlight } from '@/components/search/SearchHighlight';
 import { buildOrderedFacetValues } from '@/lib/search/filterMetadata';
-import type { Locale } from '@/lib/i18n';
+import { type Locale, localeToRouteLocale } from '@/lib/i18n';
 
 type Item = {
   slug: string;
@@ -275,6 +275,9 @@ export function PublicationsClient({ items, locale = 'en' }: { items: Item[]; lo
         activeFilters={activeFilters}
         sortControls={<SearchSortControls visible={Boolean(q)} sort={sort} onSortChange={setSort} texts={t} />}
         stickyMetaOnMobile
+        voiceLang={localeToRouteLocale(locale)}
+        voiceStartLabel={t.voiceStart}
+        voiceStopLabel={t.voiceStop}
       >
         <YearSelect
           years={years}

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -10,13 +10,17 @@ type SpeechRecognitionEventLike = {
   results: ArrayLike<SpeechRecognitionResultLike>;
 };
 
+type SpeechRecognitionErrorEventLike = {
+  error?: string;
+};
+
 type SpeechRecognitionLike = {
   lang: string;
   interimResults: boolean;
   continuous: boolean;
   onresult: ((event: SpeechRecognitionEventLike) => void) | null;
   onend: (() => void) | null;
-  onerror: (() => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEventLike) => void) | null;
   start: () => void;
   stop: () => void;
   abort: () => void;
@@ -40,10 +44,19 @@ type Options = {
   onResult: (transcript: string, isFinal: boolean) => void;
 };
 
+export type SpeechRecognitionErrorKind = 'permission' | 'no-speech' | 'unavailable';
+
+function classifyError(error?: string): SpeechRecognitionErrorKind {
+  if (error === 'not-allowed' || error === 'service-not-allowed') return 'permission';
+  if (error === 'no-speech' || error === 'aborted') return 'no-speech';
+  return 'unavailable';
+}
+
 export function useSpeechRecognition({ lang, onResult }: Options) {
   // SSR とのハイドレーション不一致を避けるため、対応判定は mount 後に行う
   const [supported, setSupported] = useState(false);
   const [listening, setListening] = useState(false);
+  const [error, setError] = useState<SpeechRecognitionErrorKind | null>(null);
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
   const onResultRef = useRef(onResult);
   onResultRef.current = onResult;
@@ -84,18 +97,22 @@ export function useSpeechRecognition({ lang, onResult }: Options) {
       recognitionRef.current = null;
       setListening(false);
     };
-    recognition.onerror = () => {
+    recognition.onerror = (event) => {
+      console.warn('[voice-search] speech recognition error:', event.error ?? 'unknown');
       recognitionRef.current = null;
       setListening(false);
+      setError(classifyError(event.error));
     };
 
     recognitionRef.current = recognition;
     setListening(true);
+    setError(null);
     try {
       recognition.start();
     } catch {
       recognitionRef.current = null;
       setListening(false);
+      setError('unavailable');
     }
   }, [lang]);
 
@@ -104,5 +121,12 @@ export function useSpeechRecognition({ lang, onResult }: Options) {
     else start();
   }, [start, stop]);
 
-  return { supported, listening, start, stop, toggle };
+  // エラー表示は数秒で自動的に消す
+  useEffect(() => {
+    if (!error) return;
+    const timer = window.setTimeout(() => setError(null), 5000);
+    return () => window.clearTimeout(timer);
+  }, [error]);
+
+  return { supported, listening, error, start, stop, toggle };
 }

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -83,7 +83,8 @@ export function useSpeechRecognition({ lang, onResult }: Options) {
     const recognition = new Ctor();
     recognition.lang = lang;
     recognition.interimResults = true;
-    recognition.continuous = false;
+    // 停止操作 (または長い無音での自動終了) まで聞き続け、複数フレーズを積み上げる
+    recognition.continuous = true;
     recognition.onresult = (event) => {
       let transcript = '';
       let isFinal = false;

--- a/src/hooks/useSpeechRecognition.ts
+++ b/src/hooks/useSpeechRecognition.ts
@@ -1,0 +1,108 @@
+'use client';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+type SpeechRecognitionResultLike = {
+  isFinal: boolean;
+  0: { transcript: string };
+};
+
+type SpeechRecognitionEventLike = {
+  results: ArrayLike<SpeechRecognitionResultLike>;
+};
+
+type SpeechRecognitionLike = {
+  lang: string;
+  interimResults: boolean;
+  continuous: boolean;
+  onresult: ((event: SpeechRecognitionEventLike) => void) | null;
+  onend: (() => void) | null;
+  onerror: (() => void) | null;
+  start: () => void;
+  stop: () => void;
+  abort: () => void;
+};
+
+type SpeechRecognitionConstructor = new () => SpeechRecognitionLike;
+
+function getSpeechRecognitionConstructor(): SpeechRecognitionConstructor | null {
+  if (typeof window === 'undefined') return null;
+  const candidates = window as typeof window & {
+    SpeechRecognition?: SpeechRecognitionConstructor;
+    webkitSpeechRecognition?: SpeechRecognitionConstructor;
+  };
+  return candidates.SpeechRecognition ?? candidates.webkitSpeechRecognition ?? null;
+}
+
+type Options = {
+  /** BCP 47 の言語タグ (例: 'ja-JP')。認識エンジンに渡す。 */
+  lang: string;
+  /** 認識結果。interim (確定前) も isFinal=false で都度呼ばれる。 */
+  onResult: (transcript: string, isFinal: boolean) => void;
+};
+
+export function useSpeechRecognition({ lang, onResult }: Options) {
+  // SSR とのハイドレーション不一致を避けるため、対応判定は mount 後に行う
+  const [supported, setSupported] = useState(false);
+  const [listening, setListening] = useState(false);
+  const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
+  const onResultRef = useRef(onResult);
+  onResultRef.current = onResult;
+
+  useEffect(() => {
+    setSupported(getSpeechRecognitionConstructor() !== null);
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.abort();
+      recognitionRef.current = null;
+    };
+  }, []);
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop();
+  }, []);
+
+  const start = useCallback(() => {
+    const Ctor = getSpeechRecognitionConstructor();
+    if (!Ctor || recognitionRef.current) return;
+
+    const recognition = new Ctor();
+    recognition.lang = lang;
+    recognition.interimResults = true;
+    recognition.continuous = false;
+    recognition.onresult = (event) => {
+      let transcript = '';
+      let isFinal = false;
+      for (let i = 0; i < event.results.length; i += 1) {
+        transcript += event.results[i][0].transcript;
+        if (event.results[i].isFinal) isFinal = true;
+      }
+      onResultRef.current(transcript, isFinal);
+    };
+    recognition.onend = () => {
+      recognitionRef.current = null;
+      setListening(false);
+    };
+    recognition.onerror = () => {
+      recognitionRef.current = null;
+      setListening(false);
+    };
+
+    recognitionRef.current = recognition;
+    setListening(true);
+    try {
+      recognition.start();
+    } catch {
+      recognitionRef.current = null;
+      setListening(false);
+    }
+  }, [lang]);
+
+  const toggle = useCallback(() => {
+    if (recognitionRef.current) stop();
+    else start();
+  }, [start, stop]);
+
+  return { supported, listening, start, stop, toggle };
+}

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -1006,6 +1006,21 @@
     right: 2.7rem;
   }
 
+  .filter-bar__search--listening .filter-bar__search-input {
+    border-color: rgba(168, 85, 247, 0.9);
+    box-shadow:
+      0 0 0 0.2rem rgba(168, 85, 247, 0.18),
+      0 12px 26px -20px rgba(168, 85, 247, 0.5);
+  }
+
+  .filter-bar__search-status--listening {
+    color: rgb(126 34 206);
+  }
+
+  .dark .filter-bar__search-status--listening {
+    color: rgb(233 213 255);
+  }
+
   .filter-bar__search-status--error {
     color: rgb(190 18 60);
   }

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -940,6 +940,50 @@
     flex: 1 1 16rem;
   }
 
+  .filter-bar__voice {
+    position: absolute;
+    top: 50%;
+    right: 0.45rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.9rem;
+    height: 1.9rem;
+    border-radius: 9999px;
+    color: rgb(107 33 168);
+    transform: translateY(-50%);
+    transition: background-color 150ms ease, color 150ms ease;
+  }
+
+  .filter-bar__voice:hover {
+    background: rgba(168, 85, 247, 0.12);
+  }
+
+  .filter-bar__voice[data-state='listening'] {
+    color: #fff;
+    background: linear-gradient(135deg, #a855f7, #f59e0b);
+    animation: filter-bar-voice-pulse 1100ms ease-in-out infinite;
+  }
+
+  @keyframes filter-bar-voice-pulse {
+    0%,
+    100% {
+      box-shadow: 0 0 0 0 rgba(168, 85, 247, 0.45);
+    }
+
+    50% {
+      box-shadow: 0 0 0 0.35rem rgba(168, 85, 247, 0.12);
+    }
+  }
+
+  .dark .filter-bar__voice {
+    color: rgb(233 213 255);
+  }
+
+  .dark .filter-bar__voice:hover {
+    background: rgba(168, 85, 247, 0.28);
+  }
+
   .filter-bar__search-status {
     position: absolute;
     top: 50%;
@@ -956,6 +1000,10 @@
     box-shadow: 0 12px 24px -24px rgba(168, 85, 247, 0.42);
     transform: translateY(-50%);
     pointer-events: none;
+  }
+
+  .filter-bar__search--voice .filter-bar__search-status {
+    right: 2.7rem;
   }
 
   .filter-bar__search-status::before {

--- a/src/styles/ui.css
+++ b/src/styles/ui.css
@@ -1006,6 +1006,19 @@
     right: 2.7rem;
   }
 
+  .filter-bar__search-status--error {
+    color: rgb(190 18 60);
+  }
+
+  .filter-bar__search-status--error::before {
+    background: linear-gradient(135deg, #f43f5e, #f59e0b);
+    animation: none;
+  }
+
+  .dark .filter-bar__search-status--error {
+    color: rgb(253 164 175);
+  }
+
   .filter-bar__search-status::before {
     content: '';
     width: 0.45rem;

--- a/tests/components/filterbar-voice.test.tsx
+++ b/tests/components/filterbar-voice.test.tsx
@@ -84,8 +84,10 @@ describe('FilterBar voice input', () => {
     expect(recognition.started).toBe(true);
     expect(recognition.lang).toBe('ja-JP');
     expect(recognition.interimResults).toBe(true);
+    expect(recognition.continuous).toBe(true);
     expect(button).toHaveAttribute('aria-pressed', 'true');
     expect(button).toHaveAttribute('aria-label', '音声入力を停止');
+    expect(screen.getByTestId('filter-voice-listening')).toBeInTheDocument();
 
     act(() => {
       recognition.emitResult('チャイ', false);
@@ -98,6 +100,7 @@ describe('FilterBar voice input', () => {
     });
     expect(onQueryChange).toHaveBeenLastCalledWith('チャイ レシピ');
     expect(button).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.queryByTestId('filter-voice-listening')).toBeNull();
   });
 
   it('shows a permission message when microphone access is denied', () => {

--- a/tests/components/filterbar-voice.test.tsx
+++ b/tests/components/filterbar-voice.test.tsx
@@ -1,0 +1,119 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FilterBar } from '@/components/filters/FilterBar';
+
+type ResultHandler = ((event: { results: { isFinal: boolean; 0: { transcript: string } }[] }) => void) | null;
+
+class MockSpeechRecognition {
+  static instances: MockSpeechRecognition[] = [];
+  lang = '';
+  interimResults = false;
+  continuous = false;
+  onresult: ResultHandler = null;
+  onend: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  started = false;
+
+  constructor() {
+    MockSpeechRecognition.instances.push(this);
+  }
+
+  start() {
+    this.started = true;
+  }
+
+  stop() {
+    this.onend?.();
+  }
+
+  abort() {
+    this.onend?.();
+  }
+
+  emitResult(transcript: string, isFinal: boolean) {
+    this.onresult?.({ results: [{ isFinal, 0: { transcript } }] });
+  }
+}
+
+function stubSpeechRecognition() {
+  MockSpeechRecognition.instances = [];
+  vi.stubGlobal('SpeechRecognition', MockSpeechRecognition);
+}
+
+describe('FilterBar voice input', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('hides the mic button when SpeechRecognition is unavailable', () => {
+    render(
+      <FilterBar query="" onQueryChange={() => {}} placeholder="Search..." voiceLang="ja-JP" voiceStartLabel="音声で検索" />,
+    );
+    expect(screen.queryByTestId('filter-voice-button')).toBeNull();
+  });
+
+  it('hides the mic button when voiceLang is not provided', () => {
+    stubSpeechRecognition();
+    render(<FilterBar query="" onQueryChange={() => {}} placeholder="Search..." />);
+    expect(screen.queryByTestId('filter-voice-button')).toBeNull();
+  });
+
+  it('starts recognition with the given language and reflects results in the query', () => {
+    stubSpeechRecognition();
+    const onQueryChange = vi.fn();
+    render(
+      <FilterBar
+        query=""
+        onQueryChange={onQueryChange}
+        placeholder="Search..."
+        voiceLang="ja-JP"
+        voiceStartLabel="音声で検索"
+        voiceStopLabel="音声入力を停止"
+      />,
+    );
+
+    const button = screen.getByTestId('filter-voice-button');
+    expect(button).toHaveAttribute('aria-label', '音声で検索');
+    fireEvent.click(button);
+
+    const recognition = MockSpeechRecognition.instances[0];
+    expect(recognition.started).toBe(true);
+    expect(recognition.lang).toBe('ja-JP');
+    expect(recognition.interimResults).toBe(true);
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+    expect(button).toHaveAttribute('aria-label', '音声入力を停止');
+
+    act(() => {
+      recognition.emitResult('チャイ', false);
+    });
+    expect(onQueryChange).toHaveBeenLastCalledWith('チャイ');
+
+    act(() => {
+      recognition.emitResult('チャイ レシピ', true);
+      recognition.onend?.();
+    });
+    expect(onQueryChange).toHaveBeenLastCalledWith('チャイ レシピ');
+    expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('stops recognition when the mic button is clicked while listening', () => {
+    stubSpeechRecognition();
+    render(
+      <FilterBar
+        query=""
+        onQueryChange={() => {}}
+        placeholder="Search..."
+        voiceLang="en-US"
+        voiceStartLabel="Search by voice"
+        voiceStopLabel="Stop voice input"
+      />,
+    );
+
+    const button = screen.getByTestId('filter-voice-button');
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('data-state', 'listening');
+
+    fireEvent.click(button);
+    expect(button).toHaveAttribute('data-state', 'idle');
+  });
+});

--- a/tests/components/filterbar-voice.test.tsx
+++ b/tests/components/filterbar-voice.test.tsx
@@ -33,6 +33,10 @@ class MockSpeechRecognition {
   emitResult(transcript: string, isFinal: boolean) {
     this.onresult?.({ results: [{ isFinal, 0: { transcript } }] });
   }
+
+  emitError(error: string) {
+    this.onerror?.({ error });
+  }
 }
 
 function stubSpeechRecognition() {
@@ -94,6 +98,28 @@ describe('FilterBar voice input', () => {
     });
     expect(onQueryChange).toHaveBeenLastCalledWith('チャイ レシピ');
     expect(button).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('shows a permission message when microphone access is denied', () => {
+    stubSpeechRecognition();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <FilterBar
+        query=""
+        onQueryChange={() => {}}
+        placeholder="Search..."
+        voiceLang="ja-JP"
+        voicePermissionMessage="マイクの使用が許可されていません"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('filter-voice-button'));
+    act(() => {
+      MockSpeechRecognition.instances[0].emitError('not-allowed');
+    });
+
+    expect(screen.getByTestId('filter-voice-error')).toHaveTextContent('マイクの使用が許可されていません');
+    expect(screen.getByTestId('filter-voice-button')).toHaveAttribute('data-state', 'idle');
   });
 
   it('stops recognition when the mic button is clicked while listening', () => {


### PR DESCRIPTION
# WHY
allow hands-free search input on the blogs and publications pages

# WHAT
- add a mic button inside the search field (FilterBar) that starts browser-native speech recognition (SpeechRecognition / webkitSpeechRecognition) — free, no external service
- recognition language follows the page locale (ja-JP / en-US / zh-CN / fr-FR), interim results stream into the query live
- the button is hidden on browsers without support (e.g. Firefox), so nothing degrades
- localized labels for 4 locales, aria-pressed toggle state, listening pulse indicator

# VERIFICATION
- unit tests for the mic button (unsupported/hidden, language wiring, result-to-query, toggle stop)
- biome lint / tsc / vitest pass; Playwright chromium e2e 58 passed (workers=1)
- visual check of light / dark / mobile / listening states via screenshots

# NOTE
- pre-existing flake (also reproducible on develop, unrelated to this change): the blog-detail clipboard e2e tests intermittently fail locally with parallel workers, likely a hydration race after the Astro 7 merge; CI passes