### PR TITLE
chore: update affiliation to Graduate School of Science and Technology

### DIFF
--- a/src/components/home/sections/ProfileSection.stories.tsx
+++ b/src/components/home/sections/ProfileSection.stories.tsx
@@ -12,7 +12,7 @@ const meta = {
     title: 'ホームページ',
     alias: '氏名：岡田 龍樹 | Tatsuki Okada',
     handle: 'ハンドルネーム: iamtatsuki05 | iam_tatsuki05',
-    affiliation: '所属：[奈良先端科学技術大学院大学](https://www.naist.jp/) 情報科学領域 / [自然言語処理学研究室（渡辺研究室）](https://nlp.naist.jp/ja/)',
+    affiliation: '所属：[奈良先端科学技術大学院大学 (NAIST)](https://www.naist.jp/)、先端科学技術研究科情報科学領域、[自然言語処理学研究室(渡辺研究室)](https://nlp.naist.jp/ja/)',
     intro: '自然言語処理 | 機械学習 | ソフトウェア のエンジニアをしています。\nちいかわのハチワレが好きで、かわいいキャラクター全般が好きです。仮想通貨、株、テクノロジーにも興味があります。',
   },
   render: (args) => (

--- a/src/lib/seo/config.ts
+++ b/src/lib/seo/config.ts
@@ -41,7 +41,7 @@ export const siteConfig = {
       url: 'https://www.naist.jp/en/',
     },
     laboratory: {
-      name: 'Natural Language Processing Laboratory (Watanabe Laboratory), Division of Information Science',
+      name: 'Natural Language Processing Laboratory (Watanabe Lab), Graduate School of Science and Technology, Information Science',
       url: 'https://nlp.naist.jp/en/',
     },
   },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -3,7 +3,7 @@
   "intro": "I’m an engineer working in NLP, machine learning, and software.\nI like Hachiware from Chiikawa and cute characters in general. I’m also interested in cryptocurrency, stocks, and technology.",
   "alias": "Name: Tatsuki Okada | 岡田 龍樹",
   "handle": "Handles: iamtatsuki05 | iam_tatsuki05",
-  "affiliation": "Affiliation: Division of Information Science, [Nara Institute of Science and Technology (NAIST)](https://www.naist.jp/en/) / [Natural Language Processing Laboratory (Watanabe Laboratory)](https://nlp.naist.jp/en/)",
+  "affiliation": "Affiliation: [Nara Institute of Science and Technology (NAIST)](https://www.naist.jp/en/), Graduate School of Science and Technology, Information Science, [Natural Language Processing Laboratory (Watanabe Lab)](https://nlp.naist.jp/en/)",
   "latest_blog": "✨ Latest Blogs",
   "latest_pub": "📚 Recent Publications",
   "cta_more_links": "See more links",

--- a/src/locales/fr/common.json
+++ b/src/locales/fr/common.json
@@ -3,7 +3,7 @@
   "intro": "Je suis ingénieur en traitement automatique des langues, apprentissage automatique et logiciel.\nJ'aime Hachiware de Chiikawa et les personnages mignons en général. Je m'intéresse aussi aux cryptomonnaies, aux actions et aux technologies.",
   "alias": "Nom : Tatsuki Okada | 岡田 龍樹",
   "handle": "Identifiants : iamtatsuki05 | iam_tatsuki05",
-  "affiliation": "Affiliation : Division of Information Science, [Nara Institute of Science and Technology (NAIST)](https://www.naist.jp/en/) / [Natural Language Processing Laboratory (Watanabe Laboratory)](https://nlp.naist.jp/en/)",
+  "affiliation": "Affiliation : [Nara Institute of Science and Technology (NAIST)](https://www.naist.jp/en/), Graduate School of Science and Technology, Information Science, [Natural Language Processing Laboratory (Watanabe Lab)](https://nlp.naist.jp/en/)",
   "latest_blog": "✨ Derniers articles",
   "latest_pub": "📚 Publications récentes",
   "cta_more_links": "Voir plus de liens",

--- a/src/locales/ja/common.json
+++ b/src/locales/ja/common.json
@@ -3,7 +3,7 @@
   "intro": "自然言語処理 | 機械学習 | ソフトウェア のエンジニアをしています。\nちいかわのハチワレが好きで、かわいいキャラクター全般が好きです。仮想通貨、株、テクノロジーにも興味があります。",
   "alias": "氏名：岡田 龍樹 | Tatsuki Okada",
   "handle": "ハンドルネーム: iamtatsuki05 | iam_tatsuki05",
-  "affiliation": "所属：[奈良先端科学技術大学院大学](https://www.naist.jp/) 情報科学領域 / [自然言語処理学研究室（渡辺研究室）](https://nlp.naist.jp/ja/)",
+  "affiliation": "所属：[奈良先端科学技術大学院大学 (NAIST)](https://www.naist.jp/)、先端科学技術研究科情報科学領域、[自然言語処理学研究室(渡辺研究室)](https://nlp.naist.jp/ja/)",
   "latest_blog": "✨ 最新のブログ",
   "latest_pub": "📚 最近の公開物",
   "cta_more_links": "リンクをもっと見る",

--- a/src/locales/zh/common.json
+++ b/src/locales/zh/common.json
@@ -3,7 +3,7 @@
   "intro": "我是一名从事自然语言处理、机器学习和软件开发的工程师。\n我喜欢《吉伊卡哇》里的小八，也喜欢可爱的角色。除此之外，我也关注加密货币、股票和技术。",
   "alias": "姓名：冈田龙树 | Tatsuki Okada",
   "handle": "用户名：iamtatsuki05 | iam_tatsuki05",
-  "affiliation": "所属：[奈良先端科学技术大学院大学](https://www.naist.jp/en/) 信息科学领域 / [自然语言处理实验室（渡边实验室）](https://nlp.naist.jp/en/)",
+  "affiliation": "所属：[奈良先端科学技术大学院大学 (NAIST)](https://www.naist.jp/en/)、先端科学技术研究科信息科学领域、[自然语言处理实验室（渡边实验室）](https://nlp.naist.jp/en/)",
   "latest_blog": "✨ 最新博客",
   "latest_pub": "📚 最新公开成果",
   "cta_more_links": "查看更多链接",

--- a/tests/components/homecontentview.test.tsx
+++ b/tests/components/homecontentview.test.tsx
@@ -10,7 +10,8 @@ const dict = {
   intro: 'イントロ',
   alias: 'alias',
   handle: 'handle',
-  affiliation: '所属：[奈良先端科学技術大学院大学](https://www.naist.jp/) 情報科学領域 / [自然言語処理学研究室（渡辺研究室）](https://nlp.naist.jp/ja/)',
+  affiliation:
+    '所属：[奈良先端科学技術大学院大学 (NAIST)](https://www.naist.jp/)、先端科学技術研究科情報科学領域、[自然言語処理学研究室(渡辺研究室)](https://nlp.naist.jp/ja/)',
   latest_blog: '最新のブログ',
   latest_pub: '最近の公開物',
   cta_more_links: 'リンクをもっと見る',
@@ -63,7 +64,7 @@ describe('HomeContentView', () => {
     expect(getByRole('heading', { name: '最近の公開物' })).toBeVisible();
     expect(getByText('Sample Post')).toBeVisible();
     expect(getByText('Paper 1')).toBeVisible();
-    expect(getByRole('link', { name: '奈良先端科学技術大学院大学' })).toBeVisible();
-    expect(getByRole('link', { name: '自然言語処理学研究室（渡辺研究室）' })).toBeVisible();
+    expect(getByRole('link', { name: '奈良先端科学技術大学院大学 (NAIST)' })).toBeVisible();
+    expect(getByRole('link', { name: '自然言語処理学研究室(渡辺研究室)' })).toBeVisible();
   });
 });

--- a/tests/lib/seo.test.ts
+++ b/tests/lib/seo.test.ts
@@ -99,7 +99,7 @@ describe('structured profile metadata', () => {
 
     expect(person.worksFor?.['@type']).toBe('Organization');
     expect(person.worksFor?.name).toBe(
-      'Natural Language Processing Laboratory (Watanabe Laboratory), Division of Information Science',
+      'Natural Language Processing Laboratory (Watanabe Lab), Graduate School of Science and Technology, Information Science',
     );
     expect(person.worksFor?.url).toBe('https://nlp.naist.jp/en/');
     expect(person.worksFor?.parentOrganization?.['@type']).toBe('CollegeOrUniversity');
@@ -111,7 +111,7 @@ describe('structured profile metadata', () => {
     const profile = buildOrganizationJsonLd();
 
     expect(profile.mainEntity.worksFor?.name).toBe(
-      'Natural Language Processing Laboratory (Watanabe Laboratory), Division of Information Science',
+      'Natural Language Processing Laboratory (Watanabe Lab), Graduate School of Science and Technology, Information Science',
     );
     expect(profile.mainEntity.worksFor?.parentOrganization?.name).toBe(
       'Nara Institute of Science and Technology (NAIST)',


### PR DESCRIPTION
# WHY
reflect the current affiliation

# WHAT
- update the profile affiliation text in all four locales (ja/en/zh/fr) to 奈良先端科学技術大学院大学 (NAIST)、先端科学技術研究科情報科学領域、自然言語処理学研究室(渡辺研究室) / Graduate School of Science and Technology, Information Science, Natural Language Processing Laboratory (Watanabe Lab)
- update the laboratory name in the Person/ProfilePage JSON-LD (`siteConfig.affiliation`)
- update test and Storybook fixtures accordingly

# VERIFICATION
- biome lint / tsc / vitest pass; built HTML checked for the new text, links, and JSON-LD on ja and en pages; profile section screenshots verified visually