### PR TITLE
chore(lint): exclude the .claude directory from Biome

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
 			"!**/out",
 			"!**/storybook-static",
 			"!**/node_modules",
-			"!**/.cache"
+			"!**/.cache",
+			"!**/.claude"
 		]
 	},
 	"formatter": {


### PR DESCRIPTION
# WHY
`biome check .` fails when agent worktrees under `.claude/worktrees` contain checkouts of older branches with 1.x-schema biome.json files

# WHAT
- add `!**/.claude` to the Biome files.includes exclusions, alongside node_modules and .cache

# VERIFICATION
- `bun run lint` passes from the repository root with worktrees present