### PR TITLE
chore: add Renovate config for automated dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "baseBranches": ["develop"],
+  "timezone": "Asia/Tokyo",
+  "schedule": ["before 9am on monday"],
+  "rangeStrategy": "replace",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 0,
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "minor and patch dependencies"
+    },
+    {
+      "matchPackageNames": ["playwright", "@playwright/test", "playwright-core"],
+      "groupName": "playwright"
+    }
+  ]
+}


### PR DESCRIPTION
# WHY
keep dependencies current automatically instead of manual bulk updates

# WHAT
- add `renovate.json`: config:recommended base, PRs target `develop`, weekly schedule (Monday morning, Asia/Tokyo)
- group minor/patch updates into one PR; majors stay individual
- playwright packages are grouped together so the `overrides` pin and `@playwright/test` never diverge
- `rangeStrategy: replace` keeps the existing exact-pin style

# VERIFICATION
- `renovate-config-validator` passes
- note: the Renovate GitHub App still needs to be installed/enabled on this repository for the config to take effect