### PR TITLE
fix(storybook): make the Storybook tsconfig type-check cleanly

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -12,9 +12,6 @@ const config: StorybookConfig = {
     name: '@storybook/react-vite',
     options: {},
   },
-  docs: {
-    autodocs: 'tag',
-  },
   viteFinal: async (baseConfig) => ({
     ...baseConfig,
     resolve: {

--- a/.storybook/tsconfig.json
+++ b/.storybook/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": ["node"]
+    "types": ["node", "vite/client"]
   },
   "include": ["../src/components/**/*", "./**/*"]
 }


### PR DESCRIPTION
# WHY
`tsc -p .storybook/tsconfig.json` (IDE type checking) reported errors after the Storybook 10.4 / TypeScript 7 updates

# WHAT
- remove `docs.autodocs`, which Storybook 10 removed; all 19 stories already carry `tags: ['autodocs']`, and the built storybook-static index is identical before and after
- add `vite/client` to the tsconfig types so CSS side-effect imports and `import.meta.env` resolve

# VERIFICATION
- `tsc -p .storybook/tsconfig.json` and root `tsc --noEmit` pass on TypeScript 7
- `bun run storybook:build` succeeds with the same 19 docs entries