### PR TITLE
feat(blog): show related posts by shared tags on post pages

### DIFF
--- a/src/components/blogs/RelatedPosts.astro
+++ b/src/components/blogs/RelatedPosts.astro
@@ -1,0 +1,40 @@
+---
+import { ContentCardList } from '@/components/home/sections/ContentCardList';
+import { SectionHeader } from '@/components/home/sections/SectionHeader';
+import { SectionShell } from '@/components/home/SectionShell';
+import { buildBlogPostHref } from '@/lib/blog/navigation';
+import { type RelatedPostCandidate, selectRelatedPosts } from '@/lib/blog/relatedPosts';
+import { blogRelatedPostsHeading } from '@/lib/blog/translation';
+import { formatDate } from '@/lib/date';
+import type { Locale } from '@/lib/i18n';
+
+type Props = {
+  posts: RelatedPostCandidate[];
+  currentSlug: string;
+  locale?: Locale;
+  // locale prefix なしルートではリンクも prefix なしに保つため未指定のまま使う
+  hrefLocale?: Locale;
+};
+
+const { posts, currentSlug, locale = 'ja', hrefLocale } = Astro.props;
+const relatedPosts = selectRelatedPosts(posts, currentSlug);
+const items = relatedPosts.map((post) => ({
+  key: post.slug,
+  title: post.title,
+  description: post.summary,
+  href: buildBlogPostHref(post.slug, {}, hrefLocale),
+  date: formatDate(post.date, locale),
+  linkTestId: 'blog-related-post-link',
+}));
+---
+
+{items.length > 0 ? (
+  <SectionShell tone="amber" className="not-prose mt-12" data-testid="blog-related-posts">
+    <SectionHeader title={blogRelatedPostsHeading[locale]} tone="amber" />
+    <ContentCardList
+      items={items}
+      listTestId="blog-related-posts-list"
+      cardTestId="blog-related-post-card"
+    />
+  </SectionShell>
+) : null}

--- a/src/components/pages/BlogPostPage.astro
+++ b/src/components/pages/BlogPostPage.astro
@@ -6,6 +6,7 @@ import { ShareButtons } from '@/components/blogs/ShareButtons';
 import { MarkdownCopyButton } from '@/components/blogs/MarkdownCopyButton';
 import { BlogPostMeta } from '@/components/blogs/BlogPostMeta';
 import { BlogAdjacentNavigationClient } from '@/components/blogs/BlogAdjacentNavigationClient';
+import RelatedPosts from '@/components/blogs/RelatedPosts.astro';
 import { CodeCopyClient } from '@/components/site/CodeCopyClient';
 import { EmbedsClient } from '@/components/site/EmbedsClient';
 import type { BlogPost } from '@/lib/content/blog';
@@ -107,6 +108,7 @@ function toIsoString(input?: string | null) {
         <MarkdownCopyButton markdown={markdown || ''} className="ml-auto" locale={locale} client:load />
       </div>
       <div set:html={html || ''} />
+      <RelatedPosts posts={allPosts} currentSlug={slug} locale={locale} {...(routeLocale ? { hrefLocale: locale } : {})} />
       <BlogAdjacentNavigationClient posts={allPosts} currentSlug={slug} {...navigationProps} client:load />
       <CodeCopyClient locale={locale} client:load />
       <EmbedsClient client:load />

--- a/src/lib/blog/relatedPosts.ts
+++ b/src/lib/blog/relatedPosts.ts
@@ -1,0 +1,35 @@
+import type { BlogPost } from '@/lib/content/blog';
+
+export type RelatedPostCandidate = Pick<BlogPost, 'slug' | 'title' | 'date' | 'tags' | 'summary'>;
+
+export const RELATED_POSTS_LIMIT = 3;
+
+export function selectRelatedPosts<T extends RelatedPostCandidate>(
+  posts: T[],
+  currentSlug: string,
+  limit: number = RELATED_POSTS_LIMIT,
+): T[] {
+  if (limit <= 0) return [];
+  const current = posts.find((post) => post.slug === currentSlug);
+  const currentTags = new Set(current?.tags ?? []);
+  if (currentTags.size === 0) return [];
+
+  return posts
+    .filter((post) => post.slug !== currentSlug)
+    .map((post) => ({
+      post,
+      commonTagCount: new Set((post.tags ?? []).filter((tag) => currentTags.has(tag))).size,
+    }))
+    .filter((entry) => entry.commonTagCount > 0)
+    .sort(
+      (a, b) =>
+        b.commonTagCount - a.commonTagCount || toTimestamp(b.post.date) - toTimestamp(a.post.date),
+    )
+    .slice(0, limit)
+    .map((entry) => entry.post);
+}
+
+function toTimestamp(dateLike: string) {
+  const time = new Date(dateLike).getTime();
+  return Number.isNaN(time) ? 0 : time;
+}

--- a/src/lib/blog/translation.ts
+++ b/src/lib/blog/translation.ts
@@ -18,6 +18,13 @@ export const blogTranslationNotice: Record<Exclude<Locale, 'ja'>, {
   },
 };
 
+export const blogRelatedPostsHeading: Record<Locale, string> = {
+  ja: '関連記事',
+  en: 'Related Posts',
+  zh: '相关文章',
+  fr: 'Articles liés',
+};
+
 export const blogAiWritingNotice: Record<Locale, string> = {
   ja: 'この記事は AI の補助を使って執筆しています。',
   en: 'This article was written with AI assistance.',

--- a/tests/lib/blog-related-posts.test.ts
+++ b/tests/lib/blog-related-posts.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { selectRelatedPosts } from '@/lib/blog/relatedPosts';
+
+const posts = [
+  {
+    slug: 'current',
+    title: 'Current',
+    date: '2026-05-24',
+    tags: ['astro', 'nextjs', 'ai'],
+    summary: 'current post',
+  },
+  {
+    slug: 'two-common-tags',
+    title: 'Two Common Tags',
+    date: '2025-01-01',
+    tags: ['astro', 'ai', 'codex'],
+    summary: 'shares two tags',
+  },
+  {
+    slug: 'one-common-newer',
+    title: 'One Common Newer',
+    date: '2026-01-01',
+    tags: ['nextjs'],
+    summary: 'shares one tag, newer',
+  },
+  {
+    slug: 'one-common-older',
+    title: 'One Common Older',
+    date: '2024-01-01',
+    tags: ['nextjs', 'vibecoding'],
+    summary: 'shares one tag, older',
+  },
+  {
+    slug: 'no-common-tags',
+    title: 'No Common Tags',
+    date: '2026-06-01',
+    tags: ['dotfiles', 'nix'],
+    summary: 'shares nothing',
+  },
+];
+
+describe('selectRelatedPosts', () => {
+  it('orders posts by common tag count, then by newest date', () => {
+    const related = selectRelatedPosts(posts, 'current');
+    expect(related.map((post) => post.slug)).toEqual([
+      'two-common-tags',
+      'one-common-newer',
+      'one-common-older',
+    ]);
+  });
+
+  it('excludes the current post itself', () => {
+    const related = selectRelatedPosts(posts, 'current');
+    expect(related.some((post) => post.slug === 'current')).toBe(false);
+  });
+
+  it('excludes posts without common tags', () => {
+    const related = selectRelatedPosts(posts, 'current');
+    expect(related.some((post) => post.slug === 'no-common-tags')).toBe(false);
+  });
+
+  it('limits the number of related posts', () => {
+    const related = selectRelatedPosts(posts, 'current', 2);
+    expect(related.map((post) => post.slug)).toEqual(['two-common-tags', 'one-common-newer']);
+  });
+
+  it('does not inflate the common tag count with duplicated tags', () => {
+    const withDuplicates = [
+      { slug: 'current', title: 'Current', date: '2026-05-24', tags: ['ai', 'ai'], summary: '' },
+      { slug: 'duplicated', title: 'Duplicated', date: '2024-01-01', tags: ['ai', 'ai'], summary: '' },
+      { slug: 'two-tags', title: 'Two Tags', date: '2023-01-01', tags: ['ai', 'astro'], summary: '' },
+    ];
+    const current = [...withDuplicates, { slug: 'astro-too', title: 'Astro Too', date: '2026-05-24', tags: ['ai', 'astro'], summary: '' }];
+    const related = selectRelatedPosts(current, 'astro-too');
+    expect(related.map((post) => post.slug)).toEqual(['two-tags', 'current', 'duplicated']);
+  });
+
+  it('returns an empty array when no post shares a tag', () => {
+    const isolated = [
+      { slug: 'a', title: 'A', date: '2026-01-01', tags: ['x'], summary: '' },
+      { slug: 'b', title: 'B', date: '2026-01-02', tags: ['y'], summary: '' },
+    ];
+    expect(selectRelatedPosts(isolated, 'a')).toEqual([]);
+  });
+
+  it('returns an empty array when the current post is missing or has no tags', () => {
+    expect(selectRelatedPosts(posts, 'unknown-slug')).toEqual([]);
+    const untagged = [
+      { slug: 'a', title: 'A', date: '2026-01-01', tags: [], summary: '' },
+      { slug: 'b', title: 'B', date: '2026-01-02', tags: ['y'], summary: '' },
+    ];
+    expect(selectRelatedPosts(untagged, 'a')).toEqual([]);
+  });
+});


### PR DESCRIPTION
# WHY
help readers find more posts after finishing an article

# WHAT
- add a related-posts section (max 3) below the article body, ranked by shared-tag count then date; hidden when there is no overlap
- pure selection logic in `lib/blog/relatedPosts.ts` with unit tests; rendering reuses SectionShell/SectionHeader/ContentCardList with no extra hydration
- localized headings (関連記事 / Related Posts / 相关文章 / Articles liés); links keep the locale-prefix behavior of each route

# VERIFICATION
- tsc / biome / vitest (82) / build pass; built HTML checked on ja, en-US, zh-CN, and fr-FR pages (headings, links, section position, no astro-island wrapper)
- read-only reviewer: no significant issues