### PR TITLE
test: wait for island hydration before clicking SSR-rendered buttons in e2e

### DIFF
--- a/e2e/helpers/hydration.ts
+++ b/e2e/helpers/hydration.ts
@@ -1,0 +1,9 @@
+import type { Page } from '@playwright/test';
+
+// Astro removes the `ssr` attribute from an astro-island once hydration completes,
+// so waiting for its removal guarantees the island's event handlers are attached.
+export async function waitForIslandHydration(page: Page, componentExport: string): Promise<void> {
+  await page.waitForSelector(`astro-island[component-export="${componentExport}"]:not([ssr])`, {
+    state: 'attached',
+  });
+}

--- a/e2e/home.spec.ts
+++ b/e2e/home.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { waitForIslandHydration } from './helpers/hydration';
 import { localizedPath } from './helpers/paths';
 
 const viewports = [
@@ -103,6 +104,7 @@ for (const { label, use } of viewports) {
       test('opens and closes the mobile menu', async ({ page }) => {
         const menu = page.locator('#mobile-menu');
 
+        await waitForIslandHydration(page, 'Header');
         await page.getByRole('button', { name: 'Open menu' }).click();
         await expect(menu).toBeVisible();
         await expect(menu).toHaveAttribute('data-state', 'open');

--- a/e2e/site-pages.spec.ts
+++ b/e2e/site-pages.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { waitForIslandHydration } from './helpers/hydration';
 import { localizedPath } from './helpers/paths';
 
 const viewports = [
@@ -200,6 +201,7 @@ for (const { label, use } of viewports) {
         }
         await expect.poll(() => new URL(page.url()).pathname).toMatch(/\/(?:ja(?:-JP)?\/)?blogs\/[\w-]+\/?$/);
 
+        await waitForIslandHydration(page, 'MarkdownCopyButton');
         const copyButton = page.getByRole('button', { name: '記事のMarkdownをコピー' });
         await expect(copyButton).toBeVisible();
         await copyButton.click();
@@ -245,6 +247,8 @@ for (const { label, use } of viewports) {
         }
         await expect.poll(() => new URL(page.url()).pathname).toMatch(/\/en-US\/blogs\/[\w-]+\/?$/);
 
+        await waitForIslandHydration(page, 'MarkdownCopyButton');
+        await waitForIslandHydration(page, 'ShareButtons');
         const copyButton = page.getByRole('button', { name: 'Copy article markdown' });
         await expect(copyButton).toBeVisible();
         await expect(copyButton).toContainText('Copy Markdown');


### PR DESCRIPTION
# WHY
three e2e tests flaked in local parallel runs: clicking a button rendered by SSR before its Astro island finished hydrating does nothing (blog copy/share buttons, home mobile menu)

# WHAT
- add `waitForIslandHydration` helper that waits for the `ssr` attribute to be removed from the target astro-island
- apply it before the first click in the two blog-detail clipboard tests and the home mobile-menu test

# VERIFICATION
- affected tests pass 10/10 and 5/5 with `--repeat-each=5`; full chromium suite 58/58 after the fix
- lint / tsc pass
- known remaining flake unrelated to hydration: one intermittent 30s `page.goto` timeout on /publications/ under heavy parallel load