### PR TITLE
feat(search): full-text search for blog posts

### DIFF
--- a/src/components/pages/BlogsClient.tsx
+++ b/src/components/pages/BlogsClient.tsx
@@ -30,6 +30,14 @@ const INITIAL_VISIBLE_COUNT = 10;
 const LOAD_MORE_INCREMENT = 10;
 const LATEST_POSTS_COUNT = 3;
 
+// タイトル/サマリ/タグのマッチを本文(searchText)より優先する。
+const BLOG_FUSE_KEYS = [
+  { name: 'title', weight: 3 },
+  { name: 'summary', weight: 2 },
+  { name: 'tags', weight: 2 },
+  { name: 'searchText', weight: 1 },
+];
+
 type Post = {
   slug: string;
   title: string;
@@ -40,6 +48,7 @@ type Post = {
   headerImageOptimizedSrc?: string;
   headerImageSrcSet?: string;
   headerAlt?: string;
+  searchText?: string;
 };
 
 export function BlogsClient({
@@ -72,7 +81,8 @@ export function BlogsClient({
     sort,
     setSort,
   } = useSearchFilters(posts, {
-    fuseKeys: ['title', 'summary', 'tags'],
+    fuseKeys: BLOG_FUSE_KEYS,
+    ignoreLocation: true,
     extractYear: (p) => p.date,
     extractTags: (p) => p.tags || [],
     extractSortValue: (p) => p.date,

--- a/src/components/pages/BlogsClient.tsx
+++ b/src/components/pages/BlogsClient.tsx
@@ -23,7 +23,7 @@ import { SectionShell } from '@/components/home/SectionShell';
 import { SectionHeader } from '@/components/home/sections/SectionHeader';
 import { SearchHighlight } from '@/components/search/SearchHighlight';
 import { useInitialReveal } from '@/hooks/useInitialReveal';
-import { buildBlogPostHref } from '@/lib/blog/navigation';
+import { BLOG_SEARCH_KEYS, buildBlogPostHref } from '@/lib/blog/navigation';
 import { type Locale, localeToRouteLocale } from '@/lib/i18n';
 
 const INITIAL_VISIBLE_COUNT = 10;
@@ -31,13 +31,6 @@ const LOAD_MORE_INCREMENT = 10;
 const LATEST_POSTS_COUNT = 3;
 
 // タイトル/サマリ/タグのマッチを本文(searchText)より優先する。
-const BLOG_FUSE_KEYS = [
-  { name: 'title', weight: 3 },
-  { name: 'summary', weight: 2 },
-  { name: 'tags', weight: 2 },
-  { name: 'searchText', weight: 1 },
-];
-
 type Post = {
   slug: string;
   title: string;
@@ -81,7 +74,7 @@ export function BlogsClient({
     sort,
     setSort,
   } = useSearchFilters(posts, {
-    fuseKeys: BLOG_FUSE_KEYS,
+    fuseKeys: BLOG_SEARCH_KEYS,
     ignoreLocation: true,
     extractYear: (p) => p.date,
     extractTags: (p) => p.tags || [],

--- a/src/hooks/useSearchFilters.ts
+++ b/src/hooks/useSearchFilters.ts
@@ -7,14 +7,18 @@ import {
   filterSearchItems,
   readSearchField,
   resolveFusePath,
+  type SearchKey,
   type SearchSortMode,
 } from '@/lib/search/filterItems';
 
-export type { SearchSortMode } from '@/lib/search/filterItems';
+export type { SearchKey, SearchSortMode } from '@/lib/search/filterItems';
 
 type Options<T> = {
-  fuseKeys: string[];
+  fuseKeys: SearchKey[];
   threshold?: number;
+  // 長い本文フィールド(searchText など)を検索対象にする場合は true にする。
+  // Fuse.js の既定では location/distance の制約で本文後半の語がマッチしないため。
+  ignoreLocation?: boolean;
   extractYear: (item: T) => string | undefined;
   extractTags: (item: T) => string[];
   extractSortValue?: (item: T) => string | number | undefined;
@@ -67,7 +71,7 @@ function writeQueryState(next: Partial<ReturnType<typeof readQueryState>>) {
 
 export function useSearchFilters<T>(
   items: T[],
-  { fuseKeys, threshold = 0.35, extractYear, extractTags, extractSortValue }: Options<T>,
+  { fuseKeys, threshold = 0.35, ignoreLocation = false, extractYear, extractTags, extractSortValue }: Options<T>,
 ) {
   const [{ q, year: selectedYears, tags, sort: selectedSort }, setQueryState] = useState(readQueryState);
   const [fuse, setFuse] = useState<Fuse<T> | null>(null);
@@ -153,6 +157,7 @@ export function useSearchFilters<T>(
           new FuseClass(items, {
             keys: fuseKeys,
             threshold,
+            ignoreLocation,
             includeScore: true,
             getFn: (item, path) => readSearchField(item, resolveFusePath(path)).map((value) => normalizeSearchText(value)),
           }),
@@ -165,7 +170,7 @@ export function useSearchFilters<T>(
 
     fuseLoadPromiseRef.current = pending;
     return pending;
-  }, [fuse, items, fuseKeys, threshold]);
+  }, [fuse, items, fuseKeys, threshold, ignoreLocation]);
 
   useEffect(() => {
     if (!localQ || fuse) return;

--- a/src/lib/blog/navigation.ts
+++ b/src/lib/blog/navigation.ts
@@ -1,6 +1,14 @@
-import type { SearchSortMode } from '@/lib/search/filterItems';
+import type { SearchKey, SearchSortMode } from '@/lib/search/filterItems';
 import type { Locale } from '@/lib/i18n';
 import { localizedPath } from '@/lib/routing';
+
+// 一覧 (BlogsClient) と前後記事ナビ (postNavigation) で検索順位が一致するよう共有する
+export const BLOG_SEARCH_KEYS: SearchKey[] = [
+  { name: 'title', weight: 3 },
+  { name: 'summary', weight: 2 },
+  { name: 'tags', weight: 2 },
+  { name: 'searchText', weight: 1 },
+];
 
 export type BlogFilterParams = {
   q?: string;

--- a/src/lib/blog/postNavigation.ts
+++ b/src/lib/blog/postNavigation.ts
@@ -1,6 +1,6 @@
 import Fuse from 'fuse.js';
 import type { BlogPost } from '@/lib/content/blog';
-import { buildBlogPostHref, type BlogFilterParams } from '@/lib/blog/navigation';
+import { BLOG_SEARCH_KEYS, buildBlogPostHref, type BlogFilterParams } from '@/lib/blog/navigation';
 import type { Locale } from '@/lib/i18n';
 import {
   filterSearchItems,
@@ -9,9 +9,7 @@ import {
 } from '@/lib/search/filterItems';
 import { normalizeSearchText } from '@/lib/search/queryTokens';
 
-type NavigableBlogPost = Pick<BlogPost, 'slug' | 'title' | 'date' | 'tags' | 'summary'>;
-
-const BLOG_SEARCH_KEYS = ['title', 'summary', 'tags'];
+type NavigableBlogPost = Pick<BlogPost, 'slug' | 'title' | 'date' | 'tags' | 'summary' | 'searchText'>;
 
 export function resolveBlogPostNavigation<T extends NavigableBlogPost>(
   posts: T[],
@@ -24,6 +22,7 @@ export function resolveBlogPostNavigation<T extends NavigableBlogPost>(
     ? new Fuse(posts, {
         keys: BLOG_SEARCH_KEYS,
         threshold: 0.35,
+        ignoreLocation: true,
         includeScore: true,
         getFn: (item, path) => readSearchField(item, resolveFusePath(path)).map((value) => normalizeSearchText(value)),
       })

--- a/src/lib/content/blog.ts
+++ b/src/lib/content/blog.ts
@@ -1,7 +1,7 @@
 import path from 'node:path';
 import { shouldIncludeDrafts } from '@/lib/config/env';
 import { BlogFrontmatter } from './types';
-import { parseMarkdownFile, slugFromFilename } from './markdown';
+import { extractMarkdownSearchText, parseMarkdownFile, slugFromFilename } from './markdown';
 import { loadCollection } from './loader';
 import { cached } from '@/lib/server/cache';
 import { resolveOptimizedBlogHeaderImage } from '@/lib/content/blogHeaderImages';
@@ -29,6 +29,7 @@ export type BlogPost = {
   html?: string;
   headings?: { id: string; title: string; level: number }[];
   markdown?: string;
+  searchText?: string;
   isAiTranslated?: boolean;
   originalPath?: string;
 };
@@ -57,7 +58,7 @@ export async function getAllPosts(locale: Locale = 'ja'): Promise<BlogPost[]> {
     dir: blogDirForLocale(locale),
     cacheKey,
     parse: async (full, filename) => {
-      const { data } = await parseMarkdownFile(full);
+      const { data, raw } = await parseMarkdownFile(full);
       const parsed = safeParseLocalized(BlogFrontmatter, data);
       if (!parsed.success) return null;
       const fm = parsed.data;
@@ -74,6 +75,7 @@ export async function getAllPosts(locale: Locale = 'ja'): Promise<BlogPost[]> {
         headerAlt: fm.headerAlt,
         aiAssisted: fm.aiAssisted,
         draft: fm.draft,
+        searchText: extractMarkdownSearchText(raw),
       }, locale);
     },
     sort: (a, b) => (a.date < b.date ? 1 : -1),

--- a/src/lib/content/markdown.ts
+++ b/src/lib/content/markdown.ts
@@ -138,3 +138,29 @@ export async function parseMarkdownFile<T>(filePath: string): Promise<{
 export function slugFromFilename(fp: string) {
   return path.basename(fp).replace(/\.mdx?$/, '');
 }
+
+export const SEARCH_TEXT_MAX_LENGTH = 4000;
+
+// 一覧ページの全文検索用に、frontmatter・コードブロック・URL・markdown 記号を落とした
+// plain text を作る。ページ payload の肥大を防ぐため既定で 4000 文字に切り詰める。
+export function extractMarkdownSearchText(source: string, maxLength = SEARCH_TEXT_MAX_LENGTH): string {
+  const { content } = matter(source);
+  const text = content
+    .replace(/```[\s\S]*?```/g, ' ')
+    .replace(/~~~[\s\S]*?~~~/g, ' ')
+    .replace(/`([^`\n]*)`/g, '$1')
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\[[^\]]*\]/g, '$1')
+    .replace(/^\s{0,3}\[[^\]]+\]:\s+\S+.*$/gm, ' ')
+    .replace(/<[^>\n]+>/g, ' ')
+    .replace(/https?:\/\/\S+/g, ' ')
+    .replace(/^\s{0,3}#{1,6}\s+/gm, '')
+    .replace(/^\s{0,3}>\s?/gm, '')
+    .replace(/^\s{0,3}(?:[-*+]|\d+\.)\s+/gm, '')
+    .replace(/^[ \t]*[-*_]{3,}[ \t]*$/gm, ' ')
+    .replace(/[*_~|\\]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return text.length > maxLength ? text.slice(0, maxLength) : text;
+}

--- a/src/lib/search/filterItems.ts
+++ b/src/lib/search/filterItems.ts
@@ -2,6 +2,13 @@ import { normalizeSearchText, tokenizeSearchQuery } from '@/lib/search/queryToke
 
 export type SearchSortMode = 'relevant' | 'newest';
 
+// Fuse.js の keys と互換の最小表現。weight 付き指定を許容する。
+export type SearchKey = string | { name: string; weight?: number };
+
+export function resolveSearchKeyName(key: SearchKey) {
+  return typeof key === 'string' ? key : key.name;
+}
+
 export type SearchMatch<T> = {
   item: T;
   score?: number;
@@ -13,7 +20,7 @@ export type SearchFilterOptions<T> = {
   sort?: SearchSortMode;
   yearSet?: Set<string>;
   tagSet?: Set<string>;
-  fuseKeys: string[];
+  fuseKeys: SearchKey[];
   extractYear: (item: T) => string | undefined;
   extractTags: (item: T) => string[];
   extractSortValue?: (item: T) => string | number | undefined;
@@ -119,10 +126,10 @@ function filterByTokens<T>({
 }: {
   items: T[];
   normalizedTokens: string[];
-  fuseKeys: string[];
+  fuseKeys: SearchKey[];
 }) {
   return items.filter((item) => {
-    const haystack = fuseKeys.flatMap((key) => readSearchField(item, key)).join(' ');
+    const haystack = fuseKeys.flatMap((key) => readSearchField(item, resolveSearchKeyName(key))).join(' ');
     const normalizedHaystack = normalizeSearchText(haystack);
 
     return normalizedTokens.every((token) => normalizedHaystack.includes(token));

--- a/tests/lib/content.blog.test.ts
+++ b/tests/lib/content.blog.test.ts
@@ -26,6 +26,17 @@ describe('content/blog', () => {
     expect(post?.html).toContain('Codex');
   });
 
+  it('includes plain searchText for list search', async () => {
+    const posts = await getAllPosts();
+    for (const post of posts) {
+      expect(post.searchText).toBeTypeOf('string');
+      expect(post.searchText?.length).toBeGreaterThan(0);
+      expect(post.searchText?.length).toBeLessThanOrEqual(4000);
+      expect(post.searchText).not.toContain('```');
+      expect(post.searchText).not.toContain('https://');
+    }
+  });
+
   it('loads AI-assisted blog metadata', async () => {
     const post = await getPostBySlug('2026-05-24-bonsai-dotfiles-ai-agent-era');
     const translated = await getPostBySlug('2026-05-24-bonsai-dotfiles-ai-agent-era', 'en');

--- a/tests/lib/markdown-searchtext.test.ts
+++ b/tests/lib/markdown-searchtext.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest';
+import { extractMarkdownSearchText, SEARCH_TEXT_MAX_LENGTH } from '@/lib/content/markdown';
+
+describe('content/markdown extractMarkdownSearchText', () => {
+  it('strips frontmatter and keeps body text', () => {
+    const source = [
+      '---',
+      'title: 記事タイトル',
+      'tags: [astro]',
+      '---',
+      '',
+      '本文の段落です。全文検索の対象になります。',
+    ].join('\n');
+
+    const text = extractMarkdownSearchText(source);
+    expect(text).toContain('本文の段落です。全文検索の対象になります。');
+    expect(text).not.toContain('title:');
+    expect(text).not.toContain('tags:');
+  });
+
+  it('removes fenced code blocks but keeps inline code text', () => {
+    const source = [
+      '前置きの文章。',
+      '',
+      '```ts',
+      'const secretInsideCode = 1;',
+      '```',
+      '',
+      '`bun install` を実行します。',
+    ].join('\n');
+
+    const text = extractMarkdownSearchText(source);
+    expect(text).not.toContain('secretInsideCode');
+    expect(text).toContain('bun install');
+    expect(text).not.toContain('```');
+  });
+
+  it('removes URLs but keeps link and image labels', () => {
+    const source = [
+      '[公式ドキュメント](https://docs.astro.build/ja/) を参照。',
+      '![代替テキスト](https://example.com/image.png)',
+      '直書き URL https://example.com/page も落とす。',
+    ].join('\n');
+
+    const text = extractMarkdownSearchText(source);
+    expect(text).toContain('公式ドキュメント');
+    expect(text).toContain('代替テキスト');
+    expect(text).not.toContain('https://');
+    expect(text).not.toContain('example.com');
+  });
+
+  it('removes markdown markers and html tags', () => {
+    const source = [
+      '## 見出しテキスト',
+      '',
+      '- 箇条書き項目',
+      '1. 番号付き項目',
+      '',
+      '> 引用の文章',
+      '',
+      '**強調** と *斜体* と ~~打ち消し~~ を含む。',
+      '',
+      '<details><summary>折りたたみ</summary>詳細内容</details>',
+      '',
+      '---',
+    ].join('\n');
+
+    const text = extractMarkdownSearchText(source);
+    expect(text).toContain('見出しテキスト');
+    expect(text).toContain('箇条書き項目');
+    expect(text).toContain('番号付き項目');
+    expect(text).toContain('引用の文章');
+    expect(text).toContain('強調 と 斜体 と 打ち消し を含む。');
+    expect(text).toContain('詳細内容');
+    for (const marker of ['##', '**', '~~', '<details>', '</summary>', '- ']) {
+      expect(text).not.toContain(marker);
+    }
+  });
+
+  it('collapses whitespace into single spaces', () => {
+    const text = extractMarkdownSearchText('一行目\n\n\n二行目   と余白');
+    expect(text).toBe('一行目 二行目 と余白');
+  });
+
+  it('truncates to the max length', () => {
+    const long = 'あいうえお'.repeat(2000);
+    expect(extractMarkdownSearchText(long).length).toBe(SEARCH_TEXT_MAX_LENGTH);
+    expect(extractMarkdownSearchText(long, 100).length).toBe(100);
+  });
+});


### PR DESCRIPTION
# WHY
the blog search only matched title/summary/tags; words that appear only in the article body returned nothing

# WHAT
- generate a `searchText` field at load time: plain text extracted from the markdown body (frontmatter, code fences, URLs, and markdown syntax stripped), capped at 4000 chars
- weighted Fuse keys (title 3 / summary 2 / tags 2 / body 1) with `ignoreLocation` so late-body words match; the pre-Fuse token filter includes the body too
- the adjacent-post navigation shares the same weighted keys, so prev/next stays consistent with the listing order for body-only matches
- publications search is unchanged

# VERIFICATION
- tsc / biome / vitest (97+82) / build pass
- manual check via playwright: a body-only word ("Lighthouse") now finds its article; title matches still rank first in mixed results
- payload cost: /blogs/ page +18.5KB raw (+7.3KB gzip) for the current 3 posts, linear in post count