### PR TITLE
feat(blog): add giscus comments to blog posts

### DIFF
--- a/src/components/blogs/GiscusComments.tsx
+++ b/src/components/blogs/GiscusComments.tsx
@@ -1,0 +1,66 @@
+'use client';
+import { useEffect, useRef } from 'react';
+import type { Locale } from '@/lib/i18n';
+
+// giscus (GitHub Discussions ベースのコメント) の埋め込み。
+// 設定値は https://giscus.app/ja で生成したもの。
+const GISCUS_REPO = 'iamtatsuki05/iamtatsuki05.github.io';
+const GISCUS_REPO_ID = 'R_kgDOPsXdHg';
+const GISCUS_CATEGORY = 'Announcements';
+const GISCUS_CATEGORY_ID = 'DIC_kwDOPsXdHs4DA5tE';
+
+const GISCUS_LANG: Record<Locale, string> = {
+  ja: 'ja',
+  en: 'en',
+  zh: 'zh-CN',
+  fr: 'fr',
+};
+
+function currentGiscusTheme() {
+  return document.documentElement.classList.contains('dark') ? 'dark' : 'light';
+}
+
+export function GiscusComments({ term, locale = 'ja' }: { term: string; locale?: Locale }) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container || container.querySelector('script')) return;
+
+    const script = document.createElement('script');
+    script.src = 'https://giscus.app/client.js';
+    script.async = true;
+    script.crossOrigin = 'anonymous';
+    script.setAttribute('data-repo', GISCUS_REPO);
+    script.setAttribute('data-repo-id', GISCUS_REPO_ID);
+    script.setAttribute('data-category', GISCUS_CATEGORY);
+    script.setAttribute('data-category-id', GISCUS_CATEGORY_ID);
+    // 全 locale で同じ記事は同じ discussion を共有する
+    script.setAttribute('data-mapping', 'specific');
+    script.setAttribute('data-term', `blog:${term}`);
+    script.setAttribute('data-strict', '0');
+    script.setAttribute('data-reactions-enabled', '1');
+    script.setAttribute('data-emit-metadata', '0');
+    script.setAttribute('data-input-position', 'bottom');
+    script.setAttribute('data-theme', currentGiscusTheme());
+    script.setAttribute('data-lang', GISCUS_LANG[locale]);
+    script.setAttribute('data-loading', 'lazy');
+    container.appendChild(script);
+
+    // サイトのテーマ切替 (html.dark の付け外し) に giscus iframe を追従させる
+    const observer = new MutationObserver(() => {
+      const iframe = container.querySelector<HTMLIFrameElement>('iframe.giscus-frame');
+      iframe?.contentWindow?.postMessage(
+        { giscus: { setConfig: { theme: currentGiscusTheme() } } },
+        'https://giscus.app',
+      );
+    });
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [term, locale]);
+
+  return <div ref={containerRef} className="giscus not-prose mt-4" data-testid="blog-comments" />;
+}

--- a/src/components/pages/BlogPostPage.astro
+++ b/src/components/pages/BlogPostPage.astro
@@ -15,7 +15,8 @@ import { absoluteUrl, buildArticleJsonLd, buildLanguageAlternates, buildPageMeta
 import { resolveLocale } from '@/lib/i18n';
 import { localizedPath } from '@/lib/routing';
 import { htmlLangFromLocale } from '@/lib/astro/metadata';
-import { blogAiWritingNotice, blogTranslationNotice } from '@/lib/blog/translation';
+import { blogAiWritingNotice, blogCommentsHeading, blogTranslationNotice } from '@/lib/blog/translation';
+import { GiscusComments } from '@/components/blogs/GiscusComments';
 
 type Props = {
   post: BlogPost;
@@ -110,6 +111,10 @@ function toIsoString(input?: string | null) {
       <div set:html={html || ''} />
       <RelatedPosts posts={allPosts} currentSlug={slug} locale={locale} {...(routeLocale ? { hrefLocale: locale } : {})} />
       <BlogAdjacentNavigationClient posts={allPosts} currentSlug={slug} {...navigationProps} client:load />
+      <section class="not-prose mt-12 border-t border-gray-200 pt-8 dark:border-gray-700" aria-label={blogCommentsHeading[locale]}>
+        <h2 class="text-xl font-semibold">{blogCommentsHeading[locale]}</h2>
+        <GiscusComments term={slug} locale={locale} client:visible />
+      </section>
       <CodeCopyClient locale={locale} client:load />
       <EmbedsClient client:load />
     </article>

--- a/src/lib/blog/translation.ts
+++ b/src/lib/blog/translation.ts
@@ -25,6 +25,13 @@ export const blogRelatedPostsHeading: Record<Locale, string> = {
   fr: 'Articles liés',
 };
 
+export const blogCommentsHeading: Record<Locale, string> = {
+  ja: 'コメント',
+  en: 'Comments',
+  zh: '评论',
+  fr: 'Commentaires',
+};
+
 export const blogAiWritingNotice: Record<Locale, string> = {
   ja: 'この記事は AI の補助を使って執筆しています。',
   en: 'This article was written with AI assistance.',

--- a/tests/components/giscus-comments.test.tsx
+++ b/tests/components/giscus-comments.test.tsx
@@ -1,0 +1,38 @@
+import { act, render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { GiscusComments } from '@/components/blogs/GiscusComments';
+
+describe('GiscusComments', () => {
+  it('injects the giscus script with the article term and locale', () => {
+    const { getByTestId } = render(<GiscusComments term="2026-05-24-next-to-astro-with-ai" locale="ja" />);
+
+    const script = getByTestId('blog-comments').querySelector('script');
+    expect(script).not.toBeNull();
+    expect(script).toHaveAttribute('src', 'https://giscus.app/client.js');
+    expect(script).toHaveAttribute('data-repo', 'iamtatsuki05/iamtatsuki05.github.io');
+    expect(script).toHaveAttribute('data-mapping', 'specific');
+    expect(script).toHaveAttribute('data-term', 'blog:2026-05-24-next-to-astro-with-ai');
+    expect(script).toHaveAttribute('data-lang', 'ja');
+    expect(script).toHaveAttribute('data-theme', 'light');
+  });
+
+  it('maps the zh locale to zh-CN and follows the current dark theme', () => {
+    document.documentElement.classList.add('dark');
+    try {
+      const { getByTestId } = render(<GiscusComments term="post" locale="zh" />);
+      const script = getByTestId('blog-comments').querySelector('script');
+      expect(script).toHaveAttribute('data-lang', 'zh-CN');
+      expect(script).toHaveAttribute('data-theme', 'dark');
+    } finally {
+      document.documentElement.classList.remove('dark');
+    }
+  });
+
+  it('does not inject the script twice across re-renders', async () => {
+    const { getByTestId, rerender } = render(<GiscusComments term="post" locale="en" />);
+    await act(async () => {
+      rerender(<GiscusComments term="post" locale="en" />);
+    });
+    expect(getByTestId('blog-comments').querySelectorAll('script')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
# WHY
let readers leave comments and reactions on blog posts without any paid service (backed by GitHub Discussions)

# WHAT
- add a comments section below each article that embeds giscus, hydrated only when scrolled into view (`client:visible`)
- the widget follows the site theme toggle via postMessage, uses the page locale for its UI (ja/en/zh-CN/fr), and all locales of an article share one discussion (slug-based `specific` mapping, Announcements category)
- localized section headings; unit tests for script wiring, locale mapping, theme detection, and re-render safety
- repository side: GitHub Discussions has been enabled on this repo

# VERIFICATION
- tsc / biome / vitest (100+89) / build pass; built HTML checked for the localized sections on ja/en/zh pages
- loaded a built page in a real browser: the giscus iframe renders the Japanese comment UI with reactions and a GitHub sign-in button
- not verifiable without a login: actually posting a comment — please try one after merging