### PR TITLE
feat: add LensLapse to publications

### DIFF
--- a/src/content/publications/app-lenslapse.md
+++ b/src/content/publications/app-lenslapse.md
@@ -1,0 +1,14 @@
+---
+title: LensLapse
+type: app
+publishedAt: 2026-07-13
+publisher: GitHub Pages
+links:
+  - { kind: app, url: https://iamtatsuki05.github.io/lenslapse/ }
+  - { kind: code, url: https://github.com/iamtatsuki05/lenslapse }
+  - { kind: video, url: https://www.youtube.com/watch?v=OBnvG9Ru3j8 }
+tags: [app, llm, interpretability, typescript, python]
+abstract: 学習チェックポイントを切り替えながら、言語モデルの層ごとの予測の変化をブラウザ上で確認できるオープンソースの可視化ツールです。
+headerImage: https://raw.githubusercontent.com/iamtatsuki05/lenslapse/d52257bc9134177906ae73cb66bc583563203711/docs/assets/readme-hero.png
+headerAlt: LensLapseの操作画面
+---


### PR DESCRIPTION
# WHY

Add the publicly available LensLapse project to the portfolio while keeping the paper-related details minimal during review.

# WHAT

- add LensLapse to the Apps section with its initial release date and a short product-focused description
- link the live demo, source repository, and demo video
- show the project screenshot from a pinned source commit
- omit the paper title, authors, venue, novelty claims, and evaluation details

# VERIFICATION

- `bun run lint`
- `bun run vitest:run` (189 tests)
- `bun run build`
- `bun run e2e:run` (58 Chromium tests)
- checked `/publications/` and `/` in a browser, including card order, image rendering, and links
- verified all external links return HTTP 200